### PR TITLE
Adding a version.rb

### DIFF
--- a/lib/vagrant-service-manager/version.rb
+++ b/lib/vagrant-service-manager/version.rb
@@ -1,0 +1,5 @@
+module Vagrant
+  module ServiceManager
+    VERSION = "0.0.1"
+  end
+end

--- a/vagrant-service-manager.gemspec
+++ b/vagrant-service-manager.gemspec
@@ -1,6 +1,9 @@
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
+require 'vagrant-service-manager/version'
+
 Gem::Specification.new do |spec|
   spec.name          = 'vagrant-service-manager'
-  spec.version       = '0.0.1'
+  spec.version       = Vagrant::ServiceManager::VERSION
   spec.homepage      = 'https://github.com/projectatomic/vagrant-service-manager'
   spec.summary       = "To provide the user a CLI to configure the ADB/CDK for different use cases and to provide glue between ADB/CDK and the user's developer environment."
 


### PR DESCRIPTION
Keeping version in version.rb helps in minimizing repetative modification
to gemspec file.

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
