### PR TITLE
Adds subcommand for displaying openshift information

### DIFF
--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -58,10 +58,14 @@ vagrant service-manager <verb> <option>
 
 Verb:
   env
-    Configures and prints the required environment variables for Docker daemon
-
-Example:
-$vagrant service-manager env docker
+    Display connection information for providers in the box.
+    Example:
+    Display information for all active providers in the box:
+      $vagrant service-manager env
+    Display information for docker provider in the box:
+      $vagrant service-manager env docker
+    Display information for openshift provider in the box:
+      $vagrant service-manager env openshift
         help
         @env.ui.info(help_text)
       end
@@ -162,7 +166,7 @@ setx OPENSHIFT_WEB_CONSOLE=#{openshift_console_url}
           husername = machine.ssh_info[:username]
 
           # Find the guest IP
-          guest_ip = self.find_machine_ip(machine)
+          guest_ip = self.find_machine_ip
 
           # Hard Code the Docker port because it is fixed on the VM
           # This also makes it easier for the plugin to be cross-provider

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -115,25 +115,12 @@ Verb:
       end
 
       def print_openshift_info(openshift_url, openshift_console_url)
-        if !OS.windows? then
-          message =
-          <<-eos
-# Set the following environment variables to access the OpenShift
-export OPENSHIFT_URL=#{openshift_url}
-export OPENSHIFT_WEB_CONSOLE=#{openshift_console_url}
-# run following command to configure your shell:
-# eval "$(vagrant service-manager env openshift)"
-          eos
-          @env.ui.info(message)
-        else
-          message =
-          <<-eos
-# Set the following environment variables to access the OpenShift
-setx OPENSHIFT_URL=#{openshift_url}
-setx OPENSHIFT_WEB_CONSOLE=#{openshift_console_url}
-          eos
-          @env.ui.info(message)
-        end
+        message =
+        <<-eos
+# You can access the OpenShift console on: #{openshift_console_url}
+# To use OpenShift CLI, run: oc login #{openshift_url}
+           eos
+        @env.ui.info(message)
       end
 
       def find_machine_ip


### PR DESCRIPTION
 Fixes #23 
 This patch adds a subcommand in plugin to display the openshift information.
 Also if given `vagrant service-manager env` it prints the status of all the providers inside the box,
 at the moment it prints the status about docker and openshift.
 If openshift service is running inside the box, it prints the required connection information and exits with 0 status.
 If openshift service is not running [not present, disabled, stopped, activating, etc], it gives the error message and exits with 1 status.
 This implementation checks for openshift service via systemd service files.
