### PR TITLE
Config + hook approach for restarting docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.3 Feb 25, 2016
+- Fix #12 and #21: Restart docker service on 'vagrant up' @budhrg
 - Fix #74: vagrant-service-manager plugin version 0.0.3 release @navidshaikh
 - Fix #45: Adds exit status for commands and invalid commands @navidshaikh
 - Enhanced the developer instructions for developing the plugin in README @budhrg

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # vagrant-service-manager
 
-Provides setup information, including environment
-variables and certificates, required to access
-services provided by an [Atomic Developer Bundle
-(ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle).
-This plugin makes it easier to use the ADB with host-based tools
-such as Eclipse and the docker and kubernetes CLI commands.
-Details on this usage pattern can be found in the [ADB
-Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
+This plugin provides setup information, including environment variables and certificates, required to access services provided by an [Atomic Developer Bundle (ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle).  This plugin makes it easier to use the ADB with host-based tools such as Eclipse and the docker and kubernetes CLI commands.  Details on this usage pattern can be found in the [ADB Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
 
 ##Objective
 
@@ -27,16 +20,28 @@ producing complex, multi-container applications.
 
 ## Quick Start
 
-1. Install `vagrant-service-manager` plugin
+1. Install `vagrant-service-manager` plugin:
 
         vagrant plugin install vagrant-service-manager
 
-2. Get the [Vagrantfile](Vagrantfile)
-and start the ADB using `vagrant up`.
-[More](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst)
-documentation on setting up ADB.
+2. Get a Vagrantfile for your box. Users of the
+[Atomic Developer Bundle (ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle) should download a [Vagrantfile from the repository](https://github.com/projectatomic/adb-atomic-developer-bundle/tree/master/components).
 
-3. Run the plugin to get environment variables and certificates
+3. Enable your desired service(s) in [Vagrantfile](Vagrantfile) as:
+
+        config.servicemanager.services = 'openshift'
+
+   *Note*
+
+   * `docker` is default service and does not require above configuration.
+   * Enable multiple services as comma separated list. Eg: 'docker, openshift'
+
+5. Start the ADB using `vagrant up`. Users of the ADB may wish to consult the
+[Installation Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst).
+
+6. Run the plugin to get environment variables and certificates:
+
+        $ vagrant service-manager env docker
 
         # Copying TLS certificates to /home/nshaikh/vagrant/adb1.7/.vagrant/machines/default/virtualbox/docker
         # Set the following environment variables to enable access to the
@@ -48,7 +53,7 @@ documentation on setting up ADB.
         # run following command to configure your shell:
         # eval "$(vagrant service-manager env docker)"
 
-4. Begin using your host-based tools.
+7. Begin using your host-based tools.
 
 ## Exit codes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+unless Vagrant.has_plugin?("vagrant-service-manager")
+  $stderr.puts <<-MSG
+    vagrant-service-manager plugin is required for projectatomic/adb.
+    Kindly install the plugin: `$ vagrant plugin install vagrant-service-manager`
+  MSG
+  exit 126
+end
+
 Vagrant.configure(2) do |config|
+
   config.vm.box = "projectatomic/adb"
 
   config.vm.network "private_network", type: "dhcp"
 
+  # This is the default setup
+  # config.servicemanager.services = 'docker'
+
+  # Enable multiple services as comma separated list.
+  # config.servicemanager.services = 'docker, openshift'
 end

--- a/lib/vagrant-service-manager.rb
+++ b/lib/vagrant-service-manager.rb
@@ -9,10 +9,13 @@ require 'vagrant-service-manager/command'
 require 'vagrant-service-manager/os'
 
 module Vagrant
-  module DockerInfo
+  module ServiceManager
     # Returns the path to the source of this plugin
     def self.source_root
       @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
     end
+
+    # Temporally load the extra capabilities files for Red Hat
+    load(File.join(source_root, 'plugins/guests/redhat/plugin.rb'))
   end
 end

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -192,13 +192,6 @@ Verb:
           # First, get the TLS Certificates, if needed
           if !File.directory?(secrets_path) then
 
-            # Regenerate the certs and restart docker daemon in case of the new ADB box and for VirtualBox provider
-            if machine.provider_name == :virtualbox then
-              # `test` checks if the file exists, and then regenerates the certs and restart the docker daemon, else do nothing.
-              command2 = "test ! -f /opt/adb/cert-gen.sh || (sudo rm /etc/docker/ca.pem && sudo systemctl restart docker)"
-              machine.communicate.execute(command2)
-            end
-
             # Get the private key
             hprivate_key_path = machine.ssh_info[:private_key_path][0]
 

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -1,0 +1,50 @@
+require 'set'
+
+module Vagrant
+  module ServiceManager
+    SERVICES = ['docker', 'openshift']
+
+    class Config < Vagrant.plugin('2', :config)
+      attr_accessor :services
+
+      DEFAULTS = {
+        services: 'docker'
+      }
+
+      def initialize
+        super
+        @services = UNSET_VALUE
+      end
+
+      def finalize!
+        DEFAULTS.each do |name, value|
+          if instance_variable_get('@' + name.to_s) == UNSET_VALUE
+            instance_variable_set '@' + name.to_s, value
+          end
+        end
+      end
+
+      def validate(machine)
+        errors = _detected_errors
+        errors.concat(validate_services)
+        { "servicemanager" => errors }
+      end
+
+      private
+
+      def validate_services
+        errors = []
+
+        unless is_supported_services?
+          errors << "services should be subset of #{SERVICES.inspect}.}"
+        end
+
+        errors
+      end
+
+      def is_supported_services?
+        @services.split(',').map(&:strip).to_set.subset?(SERVICES.to_set)
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/plugin.rb
+++ b/lib/vagrant-service-manager/plugin.rb
@@ -1,3 +1,6 @@
+# Loads all services
+Dir["#{File.dirname(__FILE__)}/services/*.rb"].each { |f| require_relative f }
+
 module Vagrant
   module ServiceManager
     class Plugin < Vagrant.plugin('2')
@@ -7,6 +10,15 @@ module Vagrant
       command 'service-manager' do
         require_relative 'command'
         Command
+      end
+
+      config 'servicemanager' do
+        require_relative 'config'
+        Config
+      end
+
+      action_hook(:servicemanager, :machine_action_up) do |hook|
+        hook.append(Service::Docker)
       end
     end
   end

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -1,0 +1,29 @@
+module Vagrant
+  module ServiceManager
+    SUPPORTED_BOXES = ['adb', 'cdk']
+
+    module Service
+      class Docker
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @ui = env[:ui]
+        end
+
+        def call(env)
+          if SUPPORTED_BOXES.include? @machine.guest.capability(:flavor)
+            command = "sudo rm /etc/docker/ca.pem && sudo systemctl restart docker"
+            @machine.communicate.execute(command) do |type, data|
+              if type == :stderr
+                @ui.error(data)
+                exit 126
+              end
+            end
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -1,0 +1,17 @@
+module VagrantPlugins
+  module GuestRedHat
+    module Cap
+      class Flavor
+        def self.flavor(machine)
+          machine.communicate.sudo("grep VARIANT_ID /etc/os-release") do |type, data|
+            if type == :stderr
+              @env.ui.error(data)
+              exit 126
+            end
+            return data.chomp.gsub(/"/, '').split("=").last
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -1,0 +1,12 @@
+require 'vagrant'
+
+module VagrantPlugins
+  module GuestRedHat
+    class Plugin < Vagrant.plugin('2')
+      guest_capability('redhat', 'flavor') do
+        require_relative 'cap/flavor'
+        Cap::Flavor
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix: #12 and #21.

With this approach `Vagrantfile` will look like

```
 Vagrant.configure(2) do |config|
  config.vm.box = "projectatomic/adb"
  config.vm.network "private_network", type: "dhcp"
  config.servicemanager.providers = 'docker'
end
```
