### PR TITLE
Fix #45: Adds exit status for commands and invalid commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased
-- Enhanced the developer instructions for developing the plugin in README
+## v0.0.3 Feb 25, 2016
+-
+- Enhanced the developer instructions for developing the plugin in README @budhrg
+- Fix #45: Adds exit status for commands and invalid commands @navidshaikh
 
 ## v0.0.2 Feb 17, 2016
 - Fixes #53: Prep for version v0.0.2

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ The [Atomic Developer Bundle](https://github.com/projectatomic/adb-atomic-develo
 
 4. Begin using your host-based tools.
 
+## Exit codes
+
+The following table lists the plugin's exit codes and their meaning:
+
+Exit Code Number | Meaning
+---------------  |-------------------------------------------------------------------------
+0                | No error
+1                | Catch all for general errors / Wrong sub-command or option given
+3                | Vagrant box is not running and must be before this command can succeed
+126              | A service inside the box is not running / Command invoked cannot execute
+
+
 ## Get Involved/Contact Us
 
   * IRC: #atomic and #nulecule on freenode


### PR DESCRIPTION
Fix #45 
- Exit with status 1, if:
  - Wrong command given / Catchall for general errors
- Exit with status 3 if:
  - Machine is not running
- Exit with status 126, if
  - Service inside the box is not running and user has asked for its connection information Or Command invoked cannot execute

Reference: http://www.tldp.org/LDP/abs/html/exitcodes.html
