### PR TITLE
Fixing "gem build" warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
   # added as the vagrant component wouldn't build without it
   gem 'json'
+  gem 'rake'
+  gem 'bundler', '~> 1.6'
 end
 
 group :plugins do

--- a/vagrant-service-manager.gemspec
+++ b/vagrant-service-manager.gemspec
@@ -4,8 +4,10 @@ require 'vagrant-service-manager/version'
 Gem::Specification.new do |spec|
   spec.name          = 'vagrant-service-manager'
   spec.version       = Vagrant::ServiceManager::VERSION
+  spec.license       = 'GPL-2.0'
   spec.homepage      = 'https://github.com/projectatomic/vagrant-service-manager'
   spec.summary       = "To provide the user a CLI to configure the ADB/CDK for different use cases and to provide glue between ADB/CDK and the user's developer environment."
+  spec.description   = "Provides setup information, including environment variables and certificates, required to access services provided by ADB/CDK."
 
   spec.authors       = ['Brian Exelbierd', 'Navid Shaikh']
   spec.email         = ['bex@pobox.com', 'nshaikh@redhat.com']
@@ -13,6 +15,4 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Bundler specific dependencies should move to Gemfile as Bundler uses the Gemfile

Fixes #66

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
