### PR TITLE
Enable private network for VirtualBox if not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix links, typos, formatting in CONTRIBUTING.md @budhrg
+- Fix #16 and #72: Enable private networking for VirtualBox if not set @budhrg
 
 ## v0.0.3 Mar 01, 2016
 - Fix #74: vagrant-service-manager plugin version 0.0.3 release @navidshaikh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,6 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "projectatomic/adb"
 
-  config.vm.network "private_network", type: "dhcp"
-
   # This is the default setup
   # config.servicemanager.services = 'docker'
 

--- a/lib/vagrant-service-manager/action/setup_network.rb
+++ b/lib/vagrant-service-manager/action/setup_network.rb
@@ -1,0 +1,38 @@
+module Vagrant
+  module ServiceManager
+    module Action
+      class SetupNetwork
+
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @ui = env[:ui]
+        end
+
+        def call(env)
+          add_private_network if virtualbox? && default_network_exists?
+          @app.call(env)
+        end
+
+        private
+
+        def virtualbox?
+          @machine.provider.instance_of?(VagrantPlugins::ProviderVirtualBox::Provider)
+        end
+
+        def default_network_exists?
+          @machine.config.vm.networks.length == 1
+        end
+
+        def add_private_network
+          @ui.info <<-MSG
+When using virtualbox, a non-NAT network interface is required.
+Adding a private network using DHCP
+          MSG
+          @machine.config.vm.network :private_network, type: :dhcp
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/plugin.rb
+++ b/lib/vagrant-service-manager/plugin.rb
@@ -1,5 +1,6 @@
-# Loads all services
+# Loads all services and actions
 Dir["#{File.dirname(__FILE__)}/services/*.rb"].each { |f| require_relative f }
+Dir["#{File.dirname(__FILE__)}/action/*.rb"].each { |f| require_relative f }
 
 module Vagrant
   module ServiceManager
@@ -18,7 +19,14 @@ module Vagrant
       end
 
       action_hook(:servicemanager, :machine_action_up) do |hook|
+        hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network, setup_network)
         hook.append(Service::Docker)
+      end
+
+      def self.setup_network
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Action::SetupNetwork
+        end
       end
     end
   end


### PR DESCRIPTION
Fix #16 and #72.

Tested on `VirtualBox` and `Libvirt` provider locally. Working as expected.
For `VirtualBox`, we get network info as info highlighted between
 `*****************************************************`  below:

```
#### Private Networking for VirtualBox on "Vagrant Up" (line no 11)

budhram@dhcp35-83 ~/r/vagrant-service-manager (fix-72)> bundle exec vagrant up

Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'projectatomic/adb'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'projectatomic/adb' is up to date...
==> default: Setting the name of the VM: vagrant-service-manager_default_1456840362014_99026
==> default: Clearing any previously set network interfaces...
*********************************************************************************************************
==> default: Virtualbox requires an additional private network. Adding it...
*********************************************************************************************************
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Remote connection disconnect. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default: 
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Configuring and enabling network interfaces...
==> default: Rsyncing folder: /home/budhram/redhat/vagrant-service-manager/ => /vagrant
```
