### PR TITLE
Fixed missing word for plugin installation in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed missing word for plugin installation in README @budhrg
 - Fix links, typos, formatting in CONTRIBUTING.md @budhrg
 - Fix #16 and #72: Enable private networking for VirtualBox if not set @budhrg
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ bundle exec rake build
 
 Install the plugin using:
 
-    vagrant install pkg/<gem name>
+    vagrant plugin install pkg/<gem name>
 
 
 ## Builds


### PR DESCRIPTION
Includes missing word in plugin installation guide. 
