### PR TITLE
enable to print export instead of setx in cygwin

### DIFF
--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -212,7 +212,7 @@ Verb:
 
         if !OS.windows? || OS.windows_cygwin? then
           if OS.windows? then
-            secrets_path = secrets_path.split('/').join('\\') + '\\'
+            secrets_path = secrets_path.split('/').join('\\')
           end
 
           message =
@@ -220,7 +220,7 @@ Verb:
 # Set the following environment variables to enable access to the
 # docker daemon running inside of the vagrant virtual machine:
 export DOCKER_HOST=tcp://#{guest_ip}:#{port}
-export DOCKER_CERT_PATH=#{secrets_path}
+export DOCKER_CERT_PATH='#{secrets_path}'
 export DOCKER_TLS_VERIFY=1
 export DOCKER_MACHINE_NAME=#{machine_uuid[0..6]}
 # run following command to configure your shell:

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -210,7 +210,11 @@ Verb:
       def print_docker_env_info(guest_ip, port, secrets_path, machine_uuid)
         # Print configuration information for accesing the docker daemon
 
-        if !OS.windows? then
+        if !OS.windows? || OS.windows_cygwin? then
+          if OS.windows? then
+            secrets_path = secrets_path.split('/').join('\\') + '\\'
+          end
+
           message =
           <<-eos
 # Set the following environment variables to enable access to the

--- a/lib/vagrant-service-manager/os.rb
+++ b/lib/vagrant-service-manager/os.rb
@@ -5,7 +5,7 @@ module OS
   end
 
   def self.windows_cygwin?
-    (/cygwin/ =~ RUBY_PLATFORM) != nil
+    (/cygwin/ =~ ENV["VAGRANT_DETECTED_OS"]) != nil
   end
 
   def self.mac?


### PR DESCRIPTION
Feature to enable bash style info in cygwin under windows.
Fixes #10 
If VAGRANT_DETECTED_OS=cygwin than print export instead of setx, but use windows-style path for cert (need to further usage).
Tested only on windows.
