### PR TITLE
Fix-72: Add a private networking for VirtualBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix-72: Add a private networking for VirtualBox @budhrg
 - Fix #113: Adds DOCKER_API_VERSION in env docker output @navidshaikh
 
 ## v0.0.4 Mar 14, 2016

--- a/lib/vagrant-service-manager/action/setup_network.rb
+++ b/lib/vagrant-service-manager/action/setup_network.rb
@@ -10,7 +10,7 @@ module Vagrant
         end
 
         def call(env)
-          add_private_network if virtualbox? && default_network_exists?
+          add_private_network if virtualbox? && !private_network_exists?
           @app.call(env)
         end
 
@@ -20,8 +20,8 @@ module Vagrant
           @machine.provider.instance_of?(VagrantPlugins::ProviderVirtualBox::Provider)
         end
 
-        def default_network_exists?
-          @machine.config.vm.networks.length == 1
+        def private_network_exists?
+          @machine.config.vm.networks.any? { |type, _| type == :private_network }
         end
 
         def add_private_network


### PR DESCRIPTION
Fix for #72 and #16 .

Explicitly checking for `private_network`. If not found, then set it.
