### PR TITLE
Fix #113: Fix #113: Adds DOCKER_API_VERSION in env docker output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix #113: Adds DOCKER_API_VERSION in env docker output @navidshaikh
+
 ## v0.0.4 Mar 14, 2016
 - Fix #101: vagrant-service-manager version 0.0.4 release @navidshaikh
 - Remove manually scp for TLS keys and use machine.communicate.download @bexelbie

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -185,12 +185,18 @@ Verb:
             machine.communicate.download("/home/vagrant/.docker/key.pem", "#{secrets_path}")
           end
 
+          api_version = ""
+          docker_apiversion = "docker version --format '{{.Server.ApiVersion}}'"
+          machine.communicate.execute(docker_apiversion) do |type, data|
+            api_version << data.chomp if type == :stdout
+          end
+
           # display the information, irrespective of the copy operation
-          self.print_docker_env_info(guest_ip, port, secrets_path, machine.index_uuid)
+          self.print_docker_env_info(guest_ip, port, secrets_path, machine.index_uuid, api_version)
         end
       end
 
-      def print_docker_env_info(guest_ip, port, secrets_path, machine_uuid)
+      def print_docker_env_info(guest_ip, port, secrets_path, machine_uuid, api_version)
         # Print configuration information for accesing the docker daemon
 
         if !OS.windows? then
@@ -202,6 +208,7 @@ export DOCKER_HOST=tcp://#{guest_ip}:#{port}
 export DOCKER_CERT_PATH=#{secrets_path}
 export DOCKER_TLS_VERIFY=1
 export DOCKER_MACHINE_NAME=#{machine_uuid[0..6]}
+export DOCKER_API_VERSION=#{api_version}
 # run following command to configure your shell:
 # eval "$(vagrant service-manager env docker)"
 
@@ -218,6 +225,7 @@ setx DOCKER_HOST tcp://#{guest_ip}:#{port}
 setx DOCKER_CERT_PATH #{secrets_path}
 setx DOCKER_TLS_VERIFY 1
 setx DOCKER_MACHINE_NAME #{machine_uuid[0..6]}
+setx DOCKER_API_VERSION=#{api_version}
           eos
           # puts is used here to escape and render the back slashes in Windows path
           @env.ui.info(puts(message))


### PR DESCRIPTION
Fixes #113 
 Sample output:

```
 $vagrant service-manager env docker
 # Set the following environment variables to enable access to the
 # docker daemon running inside of the vagrant virtual machine:
 export DOCKER_HOST=tcp://172.28.128.6:2376
 export DOCKER_CERT_PATH=/home/nshaikh/work/src/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
 export DOCKER_TLS_VERIFY=1
 export DOCKER_MACHINE_NAME=4afe4d9
 export DOCKER_API_VERSION=1.20
 # run following command to configure your shell:
 # eval "$(vagrant service-manager env docker)"
```
