### PR TITLE
Fix #121: Removes DOCKER_MACHINE_NAME from `env docker` command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #121: Removes DOCKER_MACHINE_NAME from `env docker` command output @navidshaikh
 - Fix #65: Adds --script-readable option for `env openshift` command @navidshaikh
 - Fix #80: Check for correct TLS certs pair @budhrg
 - Fix #113: Adds DOCKER_API_VERSION in env docker output @navidshaikh

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -219,11 +219,11 @@ OPENSHIFT_WEB_CONSOLE=#{openshift_console_url}
           end
 
           # display the information, irrespective of the copy operation
-          self.print_docker_env_info(find_machine_ip, port, secrets_path, machine.index_uuid, api_version)
+          self.print_docker_env_info(guest_ip, port, secrets_path, api_version)
         end
       end
 
-      def print_docker_env_info(guest_ip, port, secrets_path, machine_uuid, api_version)
+      def print_docker_env_info(guest_ip, port, secrets_path, api_version)
         # Print configuration information for accesing the docker daemon
 
         if !OS.windows? then
@@ -234,7 +234,6 @@ OPENSHIFT_WEB_CONSOLE=#{openshift_console_url}
 export DOCKER_HOST=tcp://#{guest_ip}:#{port}
 export DOCKER_CERT_PATH=#{secrets_path}
 export DOCKER_TLS_VERIFY=1
-export DOCKER_MACHINE_NAME=#{machine_uuid[0..6]}
 export DOCKER_API_VERSION=#{api_version}
 # run following command to configure your shell:
 # eval "$(vagrant service-manager env docker)"
@@ -251,7 +250,6 @@ export DOCKER_API_VERSION=#{api_version}
 setx DOCKER_HOST tcp://#{guest_ip}:#{port}
 setx DOCKER_CERT_PATH #{secrets_path}
 setx DOCKER_TLS_VERIFY 1
-setx DOCKER_MACHINE_NAME #{machine_uuid[0..6]}
 setx DOCKER_API_VERSION=#{api_version}
           eos
           # puts is used here to escape and render the back slashes in Windows path


### PR DESCRIPTION
Fixes #121 
