### PR TITLE
Fix-122: Certs copied at the time of generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #122: Certs copied at the time of generation @budhrg
 - Fix #121: Removes DOCKER_MACHINE_NAME from `env docker` command output @navidshaikh
 - Fix #65: Adds --script-readable option for `env openshift` command @navidshaikh
 - Fix #80: Check for correct TLS certs pair @budhrg

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -1,0 +1,22 @@
+module Vagrant
+  module ServiceManager
+    module PluginUtil
+      def self.copy_certs_to_host(machine, path, ui, commented_message = false)
+        Dir.mkdir(path) unless Dir.exist?(path)
+
+        # Copy the required client side certs from inside the box to host machine
+        message = "Copying TLS certificates to #{path}"
+        message = '# ' + message.to_s if commented_message
+        ui.info(message)
+        machine.communicate.download("#{DOCKER_PATH}/ca.pem", path.to_s)
+        machine.communicate.download("#{DOCKER_PATH}/cert.pem", path.to_s)
+        machine.communicate.download("#{DOCKER_PATH}/key.pem", path.to_s)
+      end
+
+      def self.host_docker_path(machine)
+        # Path to the private_key and where we will store the TLS Certificates
+        File.expand_path("docker", machine.data_dir)
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -1,3 +1,5 @@
+require_relative '../plugin_util'
+
 module Vagrant
   module ServiceManager
     class Docker
@@ -8,12 +10,16 @@ module Vagrant
 
       def execute
         command = "sudo rm /etc/docker/ca.pem && sudo systemctl restart docker"
+
         @machine.communicate.execute(command) do |type, data|
           if type == :stderr
             @ui.error(data)
             exit 126
           end
         end
+
+        secrets_path = PluginUtil.host_docker_path(@machine)
+        PluginUtil.copy_certs_to_host(@machine, secrets_path, @ui)
       end
     end
   end


### PR DESCRIPTION
Fix https://github.com/projectatomic/vagrant-service-manager/issues/122
- Implemented based on [`this comment`](https://github.com/projectatomic/vagrant-service-manager/issues/122#issuecomment-199314448)
- Extracted copying the certs operation another file so that it can be used from anywhere

My logs - https://gist.github.com/budhrg/523b8f87c954aefff9c8
