### PR TITLE
Fix#131: Fixes starting OpenShift service by default for CDK box

### DIFF
--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -12,7 +12,7 @@ module Vagrant
       attr_accessor(*CONFIG_KEYS)
 
       DEFAULTS = {
-        services: 'docker'
+        services: ''
       }
 
       def initialize

--- a/lib/vagrant-service-manager/service.rb
+++ b/lib/vagrant-service-manager/service.rb
@@ -19,13 +19,13 @@ module Vagrant
         @app.call(env)
 
         if SUPPORTED_BOXES.include? @machine.guest.capability(:os_variant)
+          # docker service needs to be started by default for ADB and CDK box
           @docker_hook.execute
 
-          if @machine.guest.capability(:os_variant) == "cdk" and @services.length == 0
+          if @machine.guest.capability(:os_variant) == "cdk" && @services.length == 0
             # openshift to be started by default for CDK
             @openshift_hook.execute
-          end
-          if @services.include? "openshift"
+          elsif @services.include? "openshift"
             # Start OpenShift service if it is configured in Vagrantfile
             @openshift_hook.execute
           end


### PR DESCRIPTION
Fixes #131 

 After this commit, following rule is applied for the box
- If the box is CDK, restart the OpenShift service by default
- If the box is CDK, and only docker service is configured, start only docker service, not the openshift service
- If the box is CDK, and only openshift service is configured, do not restart the openshift service twice
