### PR TITLE
Vagrant way of showing information using 'locale'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Vagrant way of showing information using 'locale' @budhrg
 
 ## v0.0.5 Mar 29, 2016
 - Fix #127: vagrant-service-manager 0.0.5 release @navidshaikh

--- a/lib/vagrant-service-manager.rb
+++ b/lib/vagrant-service-manager.rb
@@ -17,5 +17,7 @@ module Vagrant
 
     # Temporally load the extra capabilities files for Red Hat
     load(File.join(source_root, 'plugins/guests/redhat/plugin.rb'))
+    # Default I18n to load the en locale
+    I18n.load_path << File.expand_path("locales/en.yml", source_root)
   end
 end

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -40,7 +40,8 @@ module Vagrant
         errors = []
 
         unless is_supported_services?
-          errors << "services should be subset of #{SERVICES.inspect}.}"
+          errors << I18n.t('servicemanager.config.supported_devices',
+                           services: SERVICES.inspect)
         end
 
         errors

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,71 @@
+en:
+  servicemanager:
+    synopsis: |-
+      provides the IP address:port and tls certificate file location for a docker daemon
+    machine_should_running: |-
+      The virtual machine must be running before you execute this command.
+      Try this in the directory with your Vagrantfile:
+      vagrant up
+
+#-------------------------------------------------------------------------------
+# Translations for config validation errors
+#-------------------------------------------------------------------------------
+    config:
+      supported_devices: |-
+        services should be subset of %{services}.
+#-------------------------------------------------------------------------------
+# Translations for commands. e.g. `vagrant x`
+#-------------------------------------------------------------------------------
+    commands:
+      help: |-
+        Service manager for services inside vagrant box.
+
+        vagrant service-manager <verb> <object> [options]
+
+        Verb:
+          env
+            Display connection information for providers in the box.
+            Example:
+            Display information for all active providers in the box:
+              $vagrant service-manager env
+            Display information for docker provider in the box:
+              $vagrant service-manager env docker
+            Display information for openshift provider in the box:
+              $vagrant service-manager env openshift
+            Display information for openshift provider in script readable format:
+              $vagrant service-manager env openshift --script-readable
+
+          box
+            object
+              version : Display version and release of the running vagrant box (from /etc/os-release)
+                option
+                  --script-readable : Display the version and release in script readable (key=value) form
+      env:
+        docker:
+          windows: |-
+            # Set the following environment variables to enable access to the
+            # docker daemon running inside of the vagrant virtual machine:
+            setx DOCKER_HOST tcp://%{ip}:%{port}
+            setx DOCKER_CERT_PATH %{path}
+            setx DOCKER_TLS_VERIFY 1
+            setx DOCKER_API_VERSION=#{api_version}
+          non_windows: |-
+            # Set the following environment variables to enable access to the
+            # docker daemon running inside of the vagrant virtual machine:
+            export DOCKER_HOST=tcp://%{ip}:%{port}
+            export DOCKER_CERT_PATH=%{path}
+            export DOCKER_TLS_VERIFY=1
+            export DOCKER_API_VERSION=%{api_version}
+            # run following command to configure your shell:
+            # eval "$(vagrant service-manager env docker)"
+        openshift:
+          default: |-
+            # You can access the OpenShift console on: %{openshift_console_url}
+            # To use OpenShift CLI, run: oc login %{openshift_url}
+          script_readable: |-
+            OPENSHIFT_URL=%{openshift_url}
+            OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+        service_not_running: |-
+          # %{name} service is not running in the vagrant box.
+        nil: |-
+          # Showing the status of providers in the vagrant box:


### PR DESCRIPTION
Includes `locale` based showing of information. This way all the information are extracted into single file in `locales/en.yml`. This file is organized categorically like 

```
en
  plugin_name:
     category1: 
        sub_category1:
        ...
        sub_categoryN:
     category2:
       sub_category1:
       ...
       sub_categoryN:
```

I have tested all the possible [commands here.](https://gist.github.com/budhrg/18d4a0a2508988fc718139b70342adf2)
