### PR TITLE
Fix #133: Adds restart command for services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #133: Adds restart command for services @navidshaikh
 - Fix #152: Makes plugin backward compatible with docker 1.8.2 for docker version API @navidshaikh
 - Fix #150: Adds .gitattributes to fix the CHANGELOG.md merge conflicts @bexelbie
 - Fix #142: Removes # before human readable output of openshift env info @navidshaikh
@@ -11,6 +12,7 @@
 - Fix #89: Improve help output for service-manager -h @budhrg
 - Vagrant way of showing information using 'locale' @budhrg
 - cygwin eval hint now removes colors and env uses export @bexelbie
+- Fix #131: Fixes starting OpenShift service by default for CDK box @navidshaikh
 
 ## v0.0.5 Mar 29, 2016
 - Fix #127: vagrant-service-manager 0.0.5 release @navidshaikh

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,6 +24,7 @@ en:
           Commands:
                env          displays connection information for services in the box
                box          displays version and release information for the box
+               restart      restarts the given systemd service in the box
 
           Options:
                -h, --help   print this help
@@ -52,6 +53,20 @@ en:
           Options:
                 --script-readable  display information in a script readable format
                 -h, --help         print this help
+
+        restart: |-
+          Restarts the service
+
+          Usage: vagrant service-manager restart <object> [options]
+
+          Object:
+              Object is a service provided via sccli or systemd. For example: docker, k8s, or openshift etc.
+
+          Options:
+                -h, --help         print this help
+
+          Examples:
+            vagrant service-manager restart docker
 
       env:
         docker:


### PR DESCRIPTION
Fixes #133 
- Example execution:
  $ vagrant service-manager restart docker
  $ vagrant service-manager restart openshift
  $ vagrant service-manager restart kubernetes
  $ vagrant service-manager restart k8s
  
  For OpenShift and Kubernetes services, plugin uses sccli utility to restart the service.
  For other services, plugin uses systemctl utility to restart the service.
  If service can not be restarted, it exits with code 126.
