### PR TITLE
Fix#75 #141: Improves `vagrant service-manager env` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #75 and #141: Improves `vagrant service-manager env` output @navidshaikh
 - Fix#146: Updates docker 1.9.1 API call for `docker version` @navidshaikh
 - Update IP detection routine and fix for libvirt @bexelbie
 - Fix #50: Add --help @budhrg

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -81,4 +81,7 @@ en:
         service_not_running: |-
           # %{name} service is not running in the vagrant box.
         nil: |-
-          # Showing the status of providers in the vagrant box:
+          Configured services:
+        status:
+          running: running
+          stopped: stopped


### PR DESCRIPTION
Fixes #75 and #141 
- Adds summary of the configured services and their running status
- Does not exit with non-zero code if one of the service is stopped
- Adds separation between different provider connection info

Sample output:

```
$ vagrant service-manager env
Configured services:
docker - running
openshift - running
kubernetes - stopped

docker env:
# Set the following environment variables to enable access to the
# docker daemon running inside of the vagrant virtual machine:
export DOCKER_HOST=tcp://172.28.128.4:2376
export DOCKER_CERT_PATH=/home/nshaikh/work/src/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
export DOCKER_TLS_VERIFY=1
export DOCKER_API_VERSION=1.20
# run following command to configure your shell:
# eval "$(vagrant service-manager env docker)"

openshift env:
# You can access the OpenShift console on: https://172.28.128.4:8443/console
# To use OpenShift CLI, run: oc login https://172.28.128.4:8443

```
