### PR TITLE
Fix#146: Update docker 1.9.1 API call for `docker version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix#146: Updates docker 1.9.1 API call for `docker version` @navidshaikh
 - Update IP detection routine and fix for libvirt @bexelbie
 - Fix #50: Add --help @budhrg
 - Fix #89: Improve help output for service-manager -h @budhrg

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -176,7 +176,7 @@ module Vagrant
           end
 
           api_version = ""
-          docker_apiversion = "docker version --format '{{.Server.ApiVersion}}'"
+          docker_apiversion = "docker version --format '{{.Server.APIVersion}}'"
           machine.communicate.execute(docker_apiversion) do |type, data|
             api_version << data.chomp if type == :stdout
           end


### PR DESCRIPTION
Fixes #146 
