### PR TITLE
Update IP detection routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Update IP detection routine and fix for libvirt @bexelbie
 - Fix #50: Add --help @budhrg
 - Fix #89: Improve help output for service-manager -h @budhrg
 - Vagrant way of showing information using 'locale' @budhrg

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Exit Code Number | Meaning
 3                | Vagrant box is not running and must be before this command can succeed
 126              | A service inside the box is not running / Command invoked cannot execute
 
+## IP Address Detection
+
+There is no standarized way of detection Vagrant box IP addresses.
+This code uses the last IPv4 address available from the set of configured
+addresses that are *up*.  i.e. if eth0, eth1, and eth2 are all up and
+have IPv4 addresses, the address on eth2 is used.
 
 ## Get Involved/Contact Us
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "projectatomic/adb"
 
+  #config.vm.network "private_network", ip: "192.168.33.10"
+  #config.vm.network "private_network", type: "dhcp"
+
   # This is the default setup
   # config.servicemanager.services = 'docker'
 

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -135,14 +135,7 @@ module Vagrant
       def find_machine_ip
         with_target_vms(nil, {:single_target=>true}) do |machine|
           # Find the guest IP
-          if machine.provider_name == :virtualbox then
-            # VirtualBox automatically provisions an eth0 interface that is a NAT interface
-            # We need a routeable IP address, which will therefore be found on eth1
-            command = "ip addr show eth1 | awk 'NR==3 {print $2}' | cut -f1 -d\/"
-          else
-            # For all other provisions, find the default route
-            command = "ip route get 8.8.8.8 | awk 'NR==1 {print $NF}'"
-          end
+          command = "ip -o -4 addr show up |egrep -v ': docker|: lo' |tail -1 | awk '{print $4}' |cut -f1 -d\/"
           guest_ip = ""
           machine.communicate.execute(command) do |type, data|
             guest_ip << data.chomp if type == :stdout


### PR DESCRIPTION
IP detection was failing for libvirt when more than 1 nic was
configured.  This patch makes detection the same for all hosts.

The detection selects the last nic's IPv4 Address from all nics
that are up.

The custom detection for VirtualBox is no longer needed as we now
force add a second nic.
