### PR TITLE
Fix #142: Removes # before human readable output of openshift env info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #142: Removes # before human readable output of openshift env info @navidshaikh
 - Fix #75 and #141: Improves `vagrant service-manager env` output @navidshaikh
 - Fix#146: Updates docker 1.9.1 API call for `docker version` @navidshaikh
 - Update IP detection routine and fix for libvirt @bexelbie

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -82,8 +82,8 @@ en:
             # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env docker | tr -d '\r')"
         openshift:
           default: |-
-            # You can access the OpenShift console on: %{openshift_console_url}
-            # To use OpenShift CLI, run: oc login %{openshift_url}
+            You can access the OpenShift console on: %{openshift_console_url}
+            To use OpenShift CLI, run: oc login %{openshift_url}
           script_readable: |-
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}


### PR DESCRIPTION
Fixes #142 
 Sample output:

```
 $ vagrant service-manager env openshift
 You can access the OpenShift console on: https://172.28.128.7:8443/console
 To use OpenShift CLI, run: oc login https://172.28.128.7:8443
```
