### PR TITLE
 Fix #152: Makes plugin backward compatible with docker 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #152: Makes plugin backward compatible with docker 1.8.2 for docker version API @navidshaikh
 - Fix #150: Adds .gitattributes to fix the CHANGELOG.md merge conflicts @bexelbie
 - Fix #142: Removes # before human readable output of openshift env info @navidshaikh
 - Fix #75 and #141: Improves `vagrant service-manager env` output @navidshaikh

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -191,9 +191,14 @@ module Vagrant
           end
 
           api_version = ""
-          docker_apiversion = "docker version --format '{{.Server.APIVersion}}'"
-          machine.communicate.execute(docker_apiversion) do |type, data|
-            api_version << data.chomp if type == :stdout
+          docker_api_version = "docker version --format '{{.Server.APIVersion}}'"
+          unless machine.communicate.test(docker_api_version)
+            # fix for issue #152: Fallback to older Docker version (< 1.9.1)
+            docker_api_version.gsub!(/APIVersion/, 'ApiVersion')
+          end
+
+          machine.communicate.execute(docker_api_version) do |type, data|
+            api_version << data.chomp if type ==:stdout
           end
 
           # display the information, irrespective of the copy operation


### PR DESCRIPTION
 Fixes #152
 Makes plugin backward compatible with docker 1.8.2 for docker version API

 With this PR, plugin can work with boxes having either docker 1.9.1 or 1.8.2 version
