### PR TITLE
Check exit code instead of "stderr" stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Unreleased
-- Updated SPEC (v1.0.0) for url, date and format @budhrg 
+- Updated SPEC (v1.0.0) for url, date and format @budhrg
 - Added Table of Contents for README @bexelbie
+- Fix #160: "vagrant service-manager restart openshift" not working as expected @budhrg
+- Fix #166: For CDK box, provisioners are not executed by default on Vagrant up @budhrg
 
 ## v1.0.0 Apr 07, 2016
 - Fix #132: vagrant-service-manager 1.0.0 release @navidshaikh

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -8,14 +8,17 @@ module Vagrant
       end
 
       def execute
+        errors = []
         full_cmd = "#{@extra_cmd} sccli openshift"
 
-        @machine.communicate.sudo(full_cmd) do |type, data|
-          if type == :stderr
-            @ui.error(data)
-            exit 126
-          end
+        exit_code = @machine.communicate.sudo(full_cmd) do |type, error|
+          errors << error if type == :stderr
         end
+        unless exit_code.zero?
+          @env.ui.error errors.join("\n")
+          exit exit_code
+        end
+        exit_code
       end
 
       private


### PR DESCRIPTION
 Fixes #160 and #166

```
* Fixes #160: "vagrant service-manager restart openshift" not working
* Fixes #166: For CDK box, provisioners are not executed by default on Vagrant up
```
