### PR TITLE
Fix#173: Shows if kubernetes services is running in the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add --script-readable to env and env docker @bexelbie
 - Fix #178: Add status command and separate status from env @bexelbie
+- Fix#173: Shows if kubernetes services is running in the box @navidshaikh
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg


### PR DESCRIPTION
 Fixes #173

```
 $ vagrant service-manager env
 Configured services:
 docker - running
 openshift - stopped
 kubernetes - running

 docker env:
 # Set the following environment variables to enable access to the
 # docker daemon running inside of the vagrant virtual machine:
 export DOCKER_HOST=tcp://172.28.128.8:2376
 export DOCKER_CERT_PATH=/foo/bar/.vagrant/machines/default/virtualbox/docker
 export DOCKER_TLS_VERIFY=1
 export DOCKER_API_VERSION=1.21
 # run following command to configure your shell:
 # eval "$(vagrant service-manager env docker)"
```
