### PR TITLE
Fix #169: Adds command for displaying box routable IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add --script-readable to env and env docker @bexelbie
 - Fix #178: Add status command and separate status from env @bexelbie
 - Fix#173: Shows if kubernetes services is running in the box @navidshaikh
+- Fix #169: Adds command for displaying box routable IP address @navidshaikh
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -94,6 +94,15 @@ module Vagrant
             else
               print_help(type: command, exit_status: 1)
             end
+          when 'ip'
+            case option
+            when nil
+              display_box_ip
+            when '--help', '-h'
+              print_help(type: command)
+            else
+              print_help(type: command, exit_status: 1)
+            end
           when '--help', '-h'
             print_help(type: command)
           else
@@ -338,6 +347,10 @@ module Vagrant
           end
           exit_code
         end
+      end
+
+      def display_box_ip
+        @env.ui.info(find_machine_ip)
       end
 
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -48,6 +48,7 @@ en:
 
           Sub-Command:
                 version    display version and release information about the running VM
+                ip         display routable IP address of the running VM
 
           Options:
                 --script-readable  display information in a script readable format
@@ -61,6 +62,11 @@ en:
 
           If a service is provided, only that service is reported.
           If no service is provided only supported orchestrators are reported.
+
+          Examples:
+                vagrant service-manager box version
+                vagrant service-manager box ip
+                vagrant service-manager box version --script-readable
 
         restart: |-
           Restarts the service


### PR DESCRIPTION
 Fixes #169

```
 $ vagrant service-manager box ip
 172.28.128.8
```

 Along with this --help / -h option is added as below

```
 $ vagrant service-manager box --help
 OR
 $ vagrant service-manager box ip --help

 Usage: vagrant service-manager box <sub-command> [options]

 Sub-Command:
       version    display version and release information about the running VM
       ip         display routable IP address of the running VM

 Options:
       --script-readable  display information in a script readable format
       -h, --help         print this help

 Examples:
       vagrant service-manager box version
       vagrant service-manager box ip
       vagrant service-manager box version --script-readable
```
