### PR TITLE
Fix #188: Name of k8s service not consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Updated README to make Installation Instructions clearer @bexelbie
 - Fix #195 Adding Cucumber and Aruba based acceptance tests @hferentschik
 - CHANGELOG fix and README update for OS support for tests @budhrg
+- Fix #188: Name of k8s service not consistent @budhrg
 
 ## v1.0.2 May 09, 2016
 - Add --script-readable to env and env docker @bexelbie

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -6,8 +6,7 @@ module Vagrant
   module ServiceManager
     DOCKER_PATH = '/home/vagrant/.docker'
     SUPPORTED_SERVICES = ['docker', 'openshift', 'kubernetes']
-    SCCLI_SERVICES = ['openshift', 'k8s']
-    KUBE_NAMES = ['kubernetes', 'k8s']
+    SCCLI_SERVICES = ['openshift', 'kubernetes']
     KUBE_SERVICES = [
       'etcd', 'kube-apiserver', 'kube-controller-manager', 'kube-scheduler',
       'kubelet', 'kube-proxy', 'docker'


### PR DESCRIPTION
Fix #188 
- Removed k8s now as we will only support 'kubernetes'

It should be merged once this issue https://github.com/projectatomic/adb-utils/issues/102 is fixed.
