### PR TITLE
Fix #191: 'vagrant service-manager restart' not handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix #184: Make env headers comments for vagrant service-manager env @bexelbie
 - Fix #135: Refactor command.rb to make commands easier to add/maintain @budhrg
 - Adds @budhrg as co-maintainer for the plugin @navidshaikh
+- Fix #191: 'vagrant service-manager restart' not handled correctly @budhrg
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -107,8 +107,6 @@ module Vagrant
           case subcommand
           when '--help', '-h'
             print_help(type: command)
-          when nil
-            print_help(type: command, exit_status: 1)
           else
             restart_service(subcommand)
           end
@@ -170,6 +168,13 @@ module Vagrant
       end
 
       def restart_service(service)
+        if service.nil?
+          help_msg = I18n.t('servicemanager.commands.help.restart')
+          service_missing_msg = I18n.t('servicemanager.commands.restart.service_missing')
+          @env.ui.error help_msg.gsub(/Restarts the service/, service_missing_msg)
+          exit 126
+        end
+
         command = if SCCLI_SERVICES.include? service
                     # TODO : Handle the case where user wants to pass extra arguments
                     # to OpenShift service

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -71,10 +71,10 @@ en:
         restart: |-
           Restarts the service
 
-          Usage: vagrant service-manager restart <object> [options]
+          Usage: vagrant service-manager restart <service> [options]
 
-          Object:
-              Object is a service provided via sccli or systemd. For example:
+          Service:
+              A service provided by sccli or systemd. For example:
                docker, k8s, or openshift etc.
 
           Options:
@@ -124,6 +124,8 @@ en:
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
         service_not_running: |-
           # %{name} service is not running in the vagrant box.
+      restart:
+        service_missing: 'Service name missing'
 
       status:
         nil: |-


### PR DESCRIPTION
Fix #191 .

Now error message is following with exit code `126`:

```
$ vagrant service-manager restart
Service name missing

Usage: vagrant service-manager restart <object> [options]

Object:
    Object is a service provided via sccli or systemd. For example:
     docker, k8s, or openshift etc.

Options:
      -h, --help         print this help

Examples:
  vagrant service-manager restart docker
```
