### PR TITLE
Fix #200: Simplify the eval hint for 'vagrant service-manager env command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Adds @budhrg as co-maintainer for the plugin @navidshaikh
 - Fix #191: 'vagrant service-manager restart' not handled correctly @budhrg
 - Fixes #187, Updated commands in the Available Commands section @preeticp
+- Fix #200: Simplify the eval hint for `vagrant service-manager env` command @budhrg
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -146,6 +146,7 @@ module Vagrant
 
       def print_all_provider_info(options = {})
         with_target_vms(nil, single_target: true) do |machine|
+          options[:all] = true # flag to mark all providers
           running_service_classes = PluginUtil.running_services(machine, class: true)
 
           running_service_classes.each do |service_class|
@@ -158,6 +159,8 @@ module Vagrant
               service_class.info(machine, @env.ui, options)
             end
           end
+
+          PluginUtil.print_shell_configure_info(@env.ui) unless options[:script_readable]
         end
       end
 

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -90,6 +90,18 @@ module Vagrant
         end
         exit_code
       end
+
+      def self.print_shell_configure_info(ui, command = '')
+        label = if OS.unix?
+                  'unix_configure_info'
+                elsif OS.windows_cygwin?
+                  'windows_cygwin_configure_info'
+                end
+
+        unless label.nil?
+          ui.info "\n" + I18n.t("servicemanager.commands.env.#{label}", command: command)
+        end
+      end
     end
   end
 end

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -22,8 +22,9 @@ module Vagrant
         options[:script_readable] ||= false
 
         if PluginUtil.service_running?(machine, 'openshift')
-          url = "https://#{PluginUtil.machine_ip(machine)}:#{OPENSHIFT_PORT}"
-          print_info(ui, url, "#{url}/console", options[:script_readable])
+          options[:url] = "https://#{PluginUtil.machine_ip(machine)}:#{OPENSHIFT_PORT}"
+          options[:console_url] = "#{options[:url]}/console"
+          print_info(ui, options)
         else
           ui.error I18n.t('servicemanager.commands.env.service_not_running',
                           name: 'OpenShift')
@@ -31,16 +32,16 @@ module Vagrant
         end
       end
 
-      def self.print_info(ui, url, console_url, script_readable)
-        message = if script_readable
-                    I18n.t('servicemanager.commands.env.openshift.script_readable',
-                           openshift_url: url, openshift_console_url: console_url)
-                  else
-                    I18n.t('servicemanager.commands.env.openshift.default',
-                           openshift_url: url, openshift_console_url: console_url)
-                  end
-
+      def self.print_info(ui, options)
+        label = 'default'
+        label = 'script_readable' if options[:script_readable]
+        message = I18n.t("servicemanager.commands.env.openshift.#{label}",
+                         openshift_url: options[:url],
+                         openshift_console_url: options[:console_url])
         ui.info(message)
+        unless options[:script_readable] || options[:all]
+          PluginUtil.print_shell_configure_info(ui, ' openshift')
+        end
       end
 
       private

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -99,8 +99,6 @@ en:
             export DOCKER_CERT_PATH=%{path}
             export DOCKER_TLS_VERIFY=1
             export DOCKER_API_VERSION=%{api_version}
-            # run following command to configure your shell:
-            # eval "$(vagrant service-manager env docker)"
           windows_cygwin: |-
             # Set the following environment variables to enable access to the
             # docker daemon running inside of the vagrant virtual machine:
@@ -108,8 +106,6 @@ en:
             export DOCKER_CERT_PATH='%{path}'
             export DOCKER_TLS_VERIFY=1
             export DOCKER_API_VERSION=%{api_version}
-            # run following command to configure your shell:
-            # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env docker | tr -d '\r')"
           script_readable: |-
             DOCKER_HOST=tcp://%{ip}:%{port}
             DOCKER_CERT_PATH='%{path}'
@@ -122,6 +118,12 @@ en:
           script_readable: |-
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+        windows_cygwin_configure_info: |-
+            # run following command to configure your shell:
+            # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env%{command} | tr -d '\r')"
+        unix_configure_info: |-
+          # run following command to configure your shell:
+          # eval "$(vagrant service-manager env%{command})"
         service_not_running: |-
           # %{name} service is not running in the vagrant box.
       restart:


### PR DESCRIPTION
Fix #200.

Commands output:

```
$ vagrant service-manager env                                                
# docker env:
# Set the following environment variables to enable access to the
# docker daemon running inside of the vagrant virtual machine:
export DOCKER_HOST=tcp://10.1.2.2:2376
export DOCKER_CERT_PATH=/home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
export DOCKER_TLS_VERIFY=1
export DOCKER_API_VERSION=1.21

# openshift env:
# You can access the OpenShift console on: https://10.1.2.2:8443/console
# To use OpenShift CLI, run: oc login https://10.1.2.2:8443

# run following command to configure your shell:
# eval "$(vagrant service-manager env)"

$ vagrant service-manager env docker
# Set the following environment variables to enable access to the
# docker daemon running inside of the vagrant virtual machine:
export DOCKER_HOST=tcp://10.1.2.2:2376
export DOCKER_CERT_PATH=/home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
export DOCKER_TLS_VERIFY=1
export DOCKER_API_VERSION=1.21

# run following command to configure your shell:
# eval "$(vagrant service-manager env docker)"

$ vagrant service-manager env openshift
# You can access the OpenShift console on: https://10.1.2.2:8443/console
# To use OpenShift CLI, run: oc login https://10.1.2.2:8443

# run following command to configure your shell:
# eval "$(vagrant service-manager env openshift)"

$ vagrant service-manager env --script-readable
DOCKER_HOST=tcp://10.1.2.2:2376
DOCKER_CERT_PATH='/home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker'
DOCKER_TLS_VERIFY=1
DOCKER_API_VERSION=1.21
OPENSHIFT_URL=https://10.1.2.2:8443
OPENSHIFT_WEB_CONSOLE=https://10.1.2.2:8443/console

$ vagrant service-manager env docker --script-readable
DOCKER_HOST=tcp://10.1.2.2:2376
DOCKER_CERT_PATH='/home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker'
DOCKER_TLS_VERIFY=1
DOCKER_API_VERSION=1.21

$ vagrant service-manager env openshift --script-readable
OPENSHIFT_URL=https://10.1.2.2:8443
OPENSHIFT_WEB_CONSOLE=https://10.1.2.2:8443/console
```
