### PR TITLE
Issue 195 Acceptance test for service-manager using vagrant-spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Gemfile.lock
 .vagrant
 .bundle
 .ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 Gemfile.lock
 .vagrant
 .bundle
+.ruby-version
+.ruby-gemset
+build
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,20 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
+  gem 'vagrant',      git: 'https://github.com/mitchellh/vagrant.git'
+  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git'
+  gem 'gem-compare'
+  gem 'rake'
+  gem 'vagrant-vbguest'
+  gem 'vagrant-libvirt'
+  gem 'fog-libvirt', '0.0.3' # https://github.com/pradels/vagrant-libvirt/issues/568
+  gem 'mechanize'
+
   # added as the vagrant component wouldn't build without it
   gem 'json'
-  gem 'rake'
-  gem 'bundler', '~> 1.6'
 end
 
 group :plugins do
   gem 'vagrant-service-manager', path: '.'
+  gem 'vagrant-registration'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,186 @@
+GIT
+  remote: https://github.com/mitchellh/vagrant-spec.git
+  revision: 9bba7e1228379c0a249a06ce76ba8ea7d276afbe
+  specs:
+    vagrant-spec (0.0.1)
+      childprocess (~> 0.5.0)
+      log4r (~> 1.1.9)
+      rspec (~> 2.14)
+      thor (~> 0.18.1)
+
+GIT
+  remote: https://github.com/mitchellh/vagrant.git
+  revision: 1f88a9737369eda3dede0d3aeb30928adf82a9f7
+  specs:
+    vagrant (1.8.2.dev)
+      bundler (>= 1.5.2, <= 1.10.6)
+      childprocess (~> 0.5.0)
+      erubis (~> 2.7.0)
+      hashicorp-checkpoint (~> 0.1.1)
+      i18n (>= 0.6.0, <= 0.8.0)
+      listen (~> 3.0.2)
+      log4r (~> 1.1.9, < 1.1.11)
+      net-scp (~> 1.1.0)
+      net-sftp (~> 2.1)
+      net-ssh (~> 3.0.1)
+      nokogiri (= 1.6.7.1)
+      rb-kqueue (~> 0.2.0)
+      rest-client (>= 1.6.0, < 2.0)
+      wdm (~> 0.1.0)
+      winrm (~> 1.6)
+      winrm-fs (~> 0.3.0)
+
+PATH
+  remote: .
+  specs:
+    vagrant-service-manager (1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
+    curb (0.9.3)
+    diff-lcs (1.2.5)
+    diffy (3.1.0)
+    domain_name (0.5.20160309)
+      unf (>= 0.0.5, < 1.0.0)
+    erubis (2.7.0)
+    excon (0.49.0)
+    ffi (1.9.10)
+    fog-core (1.38.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-libvirt (0.0.3)
+      fog-core (~> 1.27, >= 1.27.4)
+      fog-json
+      fog-xml (~> 0.1.1)
+      json
+      ruby-libvirt (>= 0.5.0, < 0.7.0)
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    gem-compare (0.0.7)
+      curb
+      diffy
+      gemnasium-parser
+      json
+      rainbow
+    gemnasium-parser (0.1.9)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    hashicorp-checkpoint (0.1.4)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    httpclient (2.7.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    little-plugger (1.1.4)
+    log4r (1.1.10)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    mechanize (2.7.4)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0)
+      mime-types (>= 1.17.2, < 3)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.6)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
+    micromachine (1.1.0)
+    mime-types (2.99.1)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9.4)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.2)
+    netrc (0.11.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+    nori (2.6.0)
+    ntlm-http (0.1.1)
+    rainbow (2.1.0)
+    rake (11.1.0)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.4)
+      ffi (>= 0.5.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    ruby-libvirt (0.6.0)
+    rubyntlm (0.6.0)
+    rubyzip (1.2.0)
+    thor (0.18.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    vagrant-libvirt (0.0.33)
+      fog-libvirt (= 0.0.3)
+      nokogiri (~> 1.6.0)
+    vagrant-registration (1.2.1)
+    vagrant-vbguest (0.11.0)
+      i18n
+      log4r
+      micromachine (~> 1.1.0)
+    wdm (0.1.1)
+    webrobots (0.1.2)
+    winrm (1.7.2)
+      builder (>= 2.1.2)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0)
+    winrm-fs (0.3.2)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fog-libvirt (= 0.0.3)
+  gem-compare
+  json
+  mechanize
+  rake
+  vagrant!
+  vagrant-libvirt
+  vagrant-registration
+  vagrant-service-manager!
+  vagrant-spec!
+  vagrant-vbguest
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -3,39 +3,31 @@
 <!-- MarkdownTOC -->
 
 - [Objective](#objective)
-- [Example Execution of the Plugin](#example-execution-of-the-plugin)
-- [Available Commands](#available-commands)
-- [Exit codes](#exit-codes)
-- [IP Address Detection](#ip-address-detection)
-- [Getting Involved with the Project](#getting-involved-with-the-project)
-    - [Development](#development)
-        - [Vagrant Spec based tests](#vagrant-spec-based-tests)
+- [Usage](#usage)
+    - [Example execution of the plugin](#example-execution-of-the-plugin)
+    - [Available commands](#available-commands)
+    - [Exit codes](#exit-codes)
+    - [IP address detection](#ip-address-detection)
+- [Development](#development)
+    - [Setup](#setup)
+    - [Acceptance tests](#acceptance-tests)
     - [Builds](#builds)
+- [Getting involved](#getting-involved)
 
 <!-- /MarkdownTOC -->
 
-----
 
+<a name="objective"></a>
+# Objective
 The vagrant-service-manager plugin is designed to enable easier access to the features and services provided by the [Atomic Developer Bundle (ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle). It provides setup information, including environment variables and certificates, required to access services provided by the ADB and is a must have for most ADB users.
 
 This plugin makes it easier to use the ADB with host-based tools such as Eclipse and the docker and kubernetes CLI commands. Details on how to use ADB with this plugin can be found in the [ADB Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
 
-----
-
-<a name="objective"></a>
-## Objective
-
-The [ADB](https://github.com/projectatomic/adb-atomic-developer-bundle) provides a ready-to-use development environment for container applications. With ADB, developers can dive right into producing complex, multi-container applications.
-
-The vagrant-service-manager provides the user with:
-
-* A CLI to configure the ADB for different use cases and to provide an interface between ADB and the user's development environment.
-* A tool to control and configure the ADB from the
-developer's workstation without having to `ssh` directly into the ADB virtual machine.
-
+<a name="usage"></a>
+# Usage
 
 <a name="example-execution-of-the-plugin"></a>
-## Example Execution of the Plugin
+## Example execution of the plugin
 
 1. Install vagrant-service-manager plugin:
 
@@ -64,7 +56,7 @@ developer's workstation without having to `ssh` directly into the ADB virtual ma
 
 
 <a name="available-commands"></a>
-## Available Commands
+## Available commands
 
 The following table lists the available commands for the plugin and their explanation:
 
@@ -90,25 +82,19 @@ Exit Code Number   | Meaning
 
 
 <a name="ip-address-detection"></a>
-## IP Address Detection
+## IP address detection
 
 There is no standardized way of detecting Vagrant box IP addresses.
 This code uses the last IPv4 address available from the set of configured addresses that are *up*.  i.e. if eth0, eth1, and eth2 are all up and have IPv4 addresses, the address on eth2 is used.
 
 
-<a name="getting-involved-with-the-project"></a>
-## Getting Involved with the Project
-
-We welcome your input. You can submit issues or pull requests with respect to the vagrant-service-manager plugin. Refer to the [contributing guidelines](https://github.com/projectatomic/vagrant-service-manager/blob/master/CONTRIBUTING.md) for detailed information on how to contribute to this plugin.
-
-You can contact us on:
-  * IRC: #atomic and #nulecule on freenode
-  * Mailing List: container-tools@redhat.com
-
 <a name="development"></a>
-### Development
+# Development
 
-To setup your development environment install the [Bundler](http://bundler.io/) gem:
+<a name="setup"></a>
+## Setup
+
+After cloing the repository, install the [Bundler](http://bundler.io/) gem:
 
     $ gem install bundler
 
@@ -122,8 +108,8 @@ Rake tasks via:
 
     $ bundle exec rake -T
 
-<a name="vagrant-spec-based-tests"></a>
-#### Vagrant Spec based tests
+<a name="acceptance-tests"></a>
+## Acceptance tests
 
 The source contains also a set of [vagrant-spec](https://github.com/mitchellh/vagrant-spec) acceptance tests. They can be run via:
 
@@ -137,8 +123,19 @@ In order to for example use _libvirt_ run:
     $ bundle exec rake acceptance['libvirt']
 
 <a name="builds"></a>
-### Builds <a name="builds"></a>
+## Builds
 
 - Gem: https://rubygems.org/gems/vagrant-service-manager
-
 - Copr build: https://copr.fedorainfracloud.org/coprs/nshaikh/vagrant-service-manager/builds/
+
+<a name="getting-involved"></a>
+# Getting involved
+
+We welcome your input. You can submit issues or pull requests with respect to
+the vagrant-service-manager plugin. Refer to the
+[contributing guidelines](https://github.com/projectatomic/vagrant-service-manager/blob/master/CONTRIBUTING.md)
+for detailed information on how to contribute to this plugin.
+
+You can contact us on:
+  * IRC: #atomic and #nulecule on freenode
+  * Mailing List: container-tools@redhat.com

--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
 # vagrant-service-manager
 
-* [Objective](#objective)
-* [Example Execution of the Plugin](#example_execution)
-* [Available Commands](#commands)
-* [Exit codes](#exit_codes)
-* [IP Address Detection](#ip_addr)
-* [Getting Involved with the Project](#Contributing)
-* [Builds](#builds)
+<!-- MarkdownTOC -->
 
+- [Objective](#objective)
+- [Example Execution of the Plugin](#example-execution-of-the-plugin)
+- [Available Commands](#available-commands)
+- [Exit codes](#exit-codes)
+- [IP Address Detection](#ip-address-detection)
+- [Getting Involved with the Project](#getting-involved-with-the-project)
+    - [Development](#development)
+        - [Vagrant Spec based tests](#vagrant-spec-based-tests)
+    - [Builds](#builds)
+
+<!-- /MarkdownTOC -->
+
+----
 
 The vagrant-service-manager plugin is designed to enable easier access to the features and services provided by the [Atomic Developer Bundle (ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle). It provides setup information, including environment variables and certificates, required to access services provided by the ADB and is a must have for most ADB users.
 
 This plugin makes it easier to use the ADB with host-based tools such as Eclipse and the docker and kubernetes CLI commands. Details on how to use ADB with this plugin can be found in the [ADB Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
 
+----
 
-## Objective <a name="objective"></a>
+<a name="objective"></a>
+## Objective
 
 The [ADB](https://github.com/projectatomic/adb-atomic-developer-bundle) provides a ready-to-use development environment for container applications. With ADB, developers can dive right into producing complex, multi-container applications.
 
@@ -25,10 +34,11 @@ The vagrant-service-manager provides the user with:
 developer's workstation without having to `ssh` directly into the ADB virtual machine.
 
 
-## Example Execution of the Plugin <a name="example_execution"></a>
+<a name="example-execution-of-the-plugin"></a>
+## Example Execution of the Plugin
 
 1. Install vagrant-service-manager plugin:
- 
+
         vagrant plugin install vagrant-service-manager
 
 2. Download the relevant Vagrantfile for your [ADB](https://github.com/projectatomic/adb-atomic-developer-bundle) vagrant box, from the [repository](https://github.com/projectatomic/adb-atomic-developer-bundle/tree/master/components/centos). For further details on the usage of custom Vagrantfiles designed for specific use cases, refer to the [Usage Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
@@ -40,7 +50,7 @@ developer's workstation without having to `ssh` directly into the ADB virtual ma
 
 4. Run the plugin to get environment variables and certificates:
 
-        $ vagrant service-manager env docker       
+        $ vagrant service-manager env docker
         # Set the following environment variables to enable access to the
         # docker daemon running inside of the vagrant virtual machine:
         export DOCKER_HOST=tcp://172.28.128.4:2376
@@ -53,7 +63,8 @@ developer's workstation without having to `ssh` directly into the ADB virtual ma
 	**Note:** The required TLS certificates are copied to the host machine at the time of `vagrant up` itself. Every run of `vagrant service-manager env docker` checks for the validity of the certificates on the host machine by matching the certificates inside the box. If the certificates on the host machine are invalid, this command will also re-download the certificates onto the host machine.
 
 
-## Available Commands <a name="commands"></a>
+<a name="available-commands"></a>
+## Available Commands
 
 The following table lists the available commands for the plugin and their explanation:
 
@@ -61,11 +72,12 @@ Commands                                                   | Explanations
 -----------------------------------------------------------|-----------------------------------------
 `vagrant service-manager env`                              | Displays connection information for all active providers in the box.
 `vagrant service-manager env docker`                       | Displays connection information for the Docker provider.
-`vagrant service-manager env openshift` [--script-readable]| Displays connection information for the OpenShift provider. This is optionally available in script readable format too.
-`vagrant service-manager box version` [--script-readable]  | Displays the version and release of the running Vagrant box. This is optionally available in script readable format too.
+`vagrant service-manager env openshift [--script-readable]`| Displays connection information for the OpenShift provider. This is optionally available in script readable format too.
+`vagrant service-manager box version [--script-readable]`  | Displays the version and release of the running Vagrant box. This is optionally available in script readable format too.
 
 
-## Exit codes <a name="exit_codes"></a>
+<a name="exit-codes"></a>
+## Exit codes
 
 The following table lists the plugin's exit codes and their meaning:
 
@@ -77,13 +89,15 @@ Exit Code Number   | Meaning
 `126`              | A service inside the box is not running / Command invoked cannot execute
 
 
-## IP Address Detection <a name="ip_addr"></a>
+<a name="ip-address-detection"></a>
+## IP Address Detection
 
 There is no standardized way of detecting Vagrant box IP addresses.
 This code uses the last IPv4 address available from the set of configured addresses that are *up*.  i.e. if eth0, eth1, and eth2 are all up and have IPv4 addresses, the address on eth2 is used.
 
 
-## Getting Involved with the Project <a name="Contributing"></a>
+<a name="getting-involved-with-the-project"></a>
+## Getting Involved with the Project
 
 We welcome your input. You can submit issues or pull requests with respect to the vagrant-service-manager plugin. Refer to the [contributing guidelines](https://github.com/projectatomic/vagrant-service-manager/blob/master/CONTRIBUTING.md) for detailed information on how to contribute to this plugin.
 
@@ -91,8 +105,39 @@ You can contact us on:
   * IRC: #atomic and #nulecule on freenode
   * Mailing List: container-tools@redhat.com
 
+<a name="development"></a>
+### Development
 
-## Builds <a name="builds"></a>
+To setup your development environment install the [Bundler](http://bundler.io/) gem:
+
+    $ gem install bundler
+
+Then setup your project dependencies:
+
+    $ bundle install
+
+The build is driven via rake. All build related tash should be executed in the
+Bundler environment, e.g. `bundle exec rake clean`. You can get a list of available
+Rake tasks via:
+
+    $ bundle exec rake -T
+
+<a name="vagrant-spec-based-tests"></a>
+#### Vagrant Spec based tests
+
+The source contains also a set of [vagrant-spec](https://github.com/mitchellh/vagrant-spec) acceptance tests. They can be run via:
+
+    $ export VAGRANT_SPEC_BOX=file://<path to Vagrant box file>
+    $ bundle exec rake acceptance
+
+Setting the _VAGRANT_SPEC_BOX_ environment variable is mandatory! Any supported
+provider (virutalbox, libvirt) can be used. Per default _virtualbox_ is used.
+In order to for example use _libvirt_ run:
+
+    $ bundle exec rake acceptance['libvirt']
+
+<a name="builds"></a>
+### Builds <a name="builds"></a>
 
 - Gem: https://rubygems.org/gems/vagrant-service-manager
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,63 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/clean'
+require 'mechanize'
+require 'fileutils'
+
+CLOBBER.include('pkg')
+CLEAN.include('build')
+
+desc 'Download Vagrant box'
+task :getbox, [:provider] do |t, args|
+  if args[:provider].nil?
+    provider='virtualbox'
+  else
+    provider=args[:provider]
+  end
+  agent = Mechanize.new
+  agent.follow_meta_refresh = true
+  agent.get('https://access.redhat.com/downloads/content/293/ver=2/rhel---7/2.0.0/x86_64/product-software') do |page|
+
+    # Submit first form which is the redirect to login page form
+    login_page = page.forms.first.submit
+
+    # Submit the login form
+    after_login = login_page.form_with(:name => 'login_form') do |f|
+     username_field = f.field_with(:id => 'username')
+     username_field.value = ENV['REDHAT_USER']
+     password_field = f.field_with(:id => 'password')
+     password_field.value = ENV['REDHAT_PASSWORD']
+    end.click_button
+
+    # There is one more redirect afte successful login
+    download_page = after_login.forms.first.submit
+
+    download_page.links.each do |link|
+     if link.href =~ /rhel-cdk-kubernetes-7.2-23.x86_64.vagrant-#{Regexp.quote(provider)}.box/
+      puts "Downloading box #{link.href}"
+      download_dir = File.join(File.dirname(__FILE__), 'build', 'tmp')
+      unless File.directory?(download_dir)
+       FileUtils.mkdir_p(download_dir)
+      end
+      agent.pluggable_parser.default = Mechanize::Download
+      agent.get(link.href).save(File.join(download_dir, 'cdk.box'))
+     end
+    end
+  end
+end
+
+desc 'Run acceptance specs using vagrant-spec'
+task :acceptance, [:provider] do |t, args|
+  if args[:provider].nil?
+    provider='virtualbox'
+  else
+    provider=args[:provider]
+  end
+  build_dir = File.join(File.dirname(__FILE__), 'build')
+  unless File.directory?(build_dir)
+    FileUtils.mkdir_p(build_dir)
+  end
+  components = %w(
+    cdk
+  ).map{|s| "provider/#{provider}/#{s}" }
+  sh "export VAGRANT_SPEC_PROVIDER=#{provider} && bundle exec vagrant-spec test --components=#{components.join(' ')} | tee build/spec.log"
+end

--- a/vagrant-spec.config.rb
+++ b/vagrant-spec.config.rb
@@ -1,0 +1,13 @@
+Vagrant::Spec::Acceptance.configure do |c|
+  errors = []
+  errors << 'You need to specify the box location via the environment variable VAGRANT_SPEC_BOX' unless ENV.has_key?('VAGRANT_SPEC_BOX')
+
+  unless errors.empty?
+  	puts errors.join("\n")
+  	abort
+  end
+
+  c.provider ENV['VAGRANT_SPEC_PROVIDER'], box: ENV['VAGRANT_SPEC_BOX']
+  c.component_paths << 'vagrant-spec'
+  c.skeleton_paths  << 'vagrant-spec/skeleton'
+end

--- a/vagrant-spec/cdk_spec.rb
+++ b/vagrant-spec/cdk_spec.rb
@@ -1,0 +1,156 @@
+HELP_TEXT = <<-HELP
+Usage: vagrant service-manager <command> [options]
+
+Commands:
+     env          displays connection information for services in the box
+     box          displays box related information like version, release, IP etc
+     restart      restarts the given systemd service in the box
+     status       list services and their running state
+
+Options:
+     -h, --help   print this help
+
+For help on any individual command run `vagrant service-manager COMMAND -h`
+HELP
+
+ENV_HELP_TEXT = <<-ENV_HELP
+Usage: vagrant service-manager env [object] [options]
+
+Objects:
+      docker      display information and environment variables for docker
+      openshift   display information and environment variables for openshift
+
+If OBJECT is ommitted, display the information for all active services
+
+Options:
+      --script-readable  display information in a script readable format.
+      -h, --help         print this help
+ENV_HELP
+
+###############################################################################
+# Some helper functions
+###############################################################################
+# When running Vagrant from within a plugin development environment, Vagrant
+# prints a warning which we can ignore
+def stdout_without_plugin_context(raw_stdout)
+  raw_stdout.lines.to_a[6..-1].join
+end
+
+def command_output_is_evalable(raw_stdout)
+  console_out = stdout_without_plugin_context(raw_stdout)
+  console_out.each_line do |line|
+    expect(line).to match(/^#.*|^export [a-zA-Z_]+=.*$|^\n$/)
+  end
+end
+
+def command_output_is_script_readable(raw_stdout)
+  console_out = stdout_without_plugin_context(raw_stdout)
+  console_out.each_line do |line|
+    expect(line).to match(/^[a-zA-Z_]+=.*$/)
+  end
+end
+
+###############################################################################
+# Actual RSpec tests
+###############################################################################
+shared_examples "provider/cdk" do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box_basic option must be specified for provider: #{provider}"
+  end
+
+  include_context "acceptance"
+
+  before do
+    environment.skeleton("cdk")
+    assert_execute("vagrant", "box", "add", "box", options[:box])
+    assert_execute("vagrant", "up", "--provider=#{provider}")
+  end
+
+  after do
+    assert_execute("vagrant", "destroy", "--force")
+  end
+
+  # We put all of this in a single RSpec test so that we can test all
+  # the cases within a single VM rather than having to `vagrant up` many
+  # times.
+  it "verify cli output" do
+    ###########################################################################
+    # help
+    ###########################################################################
+    status("Test: 'service-manager env' prints env settings from all services")
+    result = execute("vagrant", "service-manager", "env", "docker")
+    expect(result).to exit_with(0)
+    command_output_is_evalable(result.stdout)
+    status("Test: service-manager with no arguments prints help")
+    result = execute("vagrant", "service-manager")
+    # TODO, why does this return an error code of 1!?
+    expect(result).to exit_with(1)
+    expect(stdout_without_plugin_context(result.stdout)).to eq(HELP_TEXT)
+
+    ###########################################################################
+    status("Test: 'service-manager -h' prints help")
+    result = execute("vagrant", "service-manager", "-h")
+    expect(result).to exit_with(0)
+    expect(stdout_without_plugin_context(result.stdout)).to eq(HELP_TEXT)
+
+    ###########################################################################
+    status("Test: 'service-manager --help' prints help")
+    result = execute("vagrant", "service-manager", "--help")
+    expect(result).to exit_with(0)
+    expect(stdout_without_plugin_context(result.stdout)).to eq(HELP_TEXT)
+
+    ###########################################################################
+    status("Test: service-manager with unkown option prints help")
+    result = execute("vagrant", "service-manager", "--foo")
+    expect(result).to exit_with(1)
+    expect(stdout_without_plugin_context(result.stdout)).to eq(HELP_TEXT)
+
+    ###########################################################################
+    # env
+    ###########################################################################
+    status("Test: 'service-manager env docker -h' prints help")
+    result = execute("vagrant", "service-manager", "env", "-h")
+    expect(result).to exit_with(0)
+    expect(stdout_without_plugin_context(result.stdout)).to eq(ENV_HELP_TEXT)
+
+    ###########################################################################
+    status("Test: 'service-manager env docker' prints evalable Docker settings")
+    result = execute("vagrant", "service-manager", "env", "docker")
+    expect(result).to exit_with(0)
+    command_output_is_evalable(result.stdout)
+    expect(result.stdout).to match(/^export DOCKER_HOST=tcp:\/\/10.10.2.2:2376/)
+    expect(result.stdout).to match(/^export DOCKER_CERT_PATH=.*\/.vagrant\/machines\/default\/#{Regexp.quote(provider)}\/docker/)
+    expect(result.stdout).to match(/^export DOCKER_TLS_VERIFY=1/)
+    expect(result.stdout).to match(/^export DOCKER_API_VERSION=1.21/)
+    expect(result.stdout).to match(/# eval "\$\(vagrant service-manager env docker\)"/)
+
+    ###########################################################################
+    status("Test: 'service-manager env docker --script-readable' prints script readable Docker settings")
+    result = execute("vagrant", "service-manager", "env", "docker", "--script-readable")
+    expect(result).to exit_with(0)
+    command_output_is_script_readable(result.stdout)
+    expect(result.stdout).to match(/^DOCKER_HOST=tcp:\/\/10.10.2.2:2376/)
+    expect(result.stdout).to match(/^DOCKER_CERT_PATH=.*\/.vagrant\/machines\/default\/#{Regexp.quote(provider)}\/docker/)
+    expect(result.stdout).to match(/^DOCKER_TLS_VERIFY=1/)
+    expect(result.stdout).to match(/^DOCKER_API_VERSION=1.21/)
+
+    ###########################################################################
+    status("Test: 'service-manager env' prints env settings from all services")
+    result = execute("vagrant", "service-manager", "env")
+    expect(result).to exit_with(0)
+    command_output_is_evalable(result.stdout)
+
+    ###########################################################################
+    status("Test: 'service-manager env' prints env settings from all services")
+    result = execute("vagrant", "service-manager", "env")
+    expect(result).to exit_with(0)
+    command_output_is_evalable(result.stdout)
+
+    ###########################################################################
+    status("Test: 'service-manager env --script-readable' prints env settings from all services sprint readable")
+    result = execute("vagrant", "service-manager", "env", "--script-readable")
+    expect(result).to exit_with(0)
+    command_output_is_script_readable(result.stdout)
+  end
+end

--- a/vagrant-spec/skeleton/cdk/Vagrantfile
+++ b/vagrant-spec/skeleton/cdk/Vagrantfile
@@ -1,0 +1,12 @@
+require 'vagrant-service-manager'
+require 'vagrant-registration'
+require 'vagrant-libvirt'
+
+Vagrant.configure(2) do |config|
+  config.vm.box = 'box'
+
+  config.registration.skip = true
+  config.vm.network 'private_network', ip: '10.10.2.2'
+
+  config.servicemanager.services = 'docker'
+end


### PR DESCRIPTION
Here is a first cut of the acceptance test harness. I want to add some more tests and maybe make some other adjustments, but I also want to share it early to get some feedback and making sure that everyone can run it.

The tests can be run against VirtualBox or Libvirt (the latter with a caveat). If you have the box file you want to use for testing already on your system, you can run the tests like:

```
$ export VAGRANT_SPEC_BOX=file://<full path to box file>
# VirtualBox
$ bundle exec rake acceptance
# Libvirt
$ bundle exec rake acceptance['libvirt']
```

Obviously the box file used needs to be the correct one for the provider. I added another helper task which can download the publicly available box files (might be nice for CI testing!?)

```
$ export REDHAT_USER=<any user who can login into access.redhat.com>
$ export REDHAT_PASSWORD=<mypass>
$ bundle exec rake getbox
# or
$ bundle exec rake getbox['libvirt']
```

Regarding the mentioned caveat. The current tests pass on OS X using the VirtualBox box. When I run the same test on Linux using Libvirt, I get one test failure. The gist seems to be that when using VirtualBox I get _DOCKER_API_VERSION=1.21_ as part of the docker env output whereas with Libvirt I get _DOCKER_API_VERSION=1.20_. 

WDYT?
