### PR TITLE
Add Environement vars to OpenShift env output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix #191: 'vagrant service-manager restart' not handled correctly @budhrg
 - Fixes #187, Updated commands in the Available Commands section @preeticp
 - Fix #200: Simplify the eval hint for `vagrant service-manager env` command @budhrg
+- Add environment variables for Openshift env output @bexelbie
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -102,6 +102,18 @@ module Vagrant
           ui.info "\n" + I18n.t("servicemanager.commands.env.#{label}", command: command)
         end
       end
+
+      def self.env_label(script_readable)
+        if script_readable
+          'script_readable'
+        elsif OS.unix?
+          'non_windows'
+        elsif OS.windows_cygwin?
+          'windows_cygwin'
+        else
+          'windows'
+        end
+      end
     end
   end
 end

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -56,16 +56,7 @@ module Vagrant
       end
 
       def self.print_env_info(ui, options)
-        label = if options[:script_readable]
-                  'script_readable'
-                elsif OS.unix?
-                  'non_windows'
-                elsif OS.windows_cygwin?
-                  'windows_cygwin'
-                else
-                  'windows'
-                end
-
+        label = PluginUtil.env_label(options[:script_readable])
         options[:secrets_path] = PluginUtil.windows_path(options[:secrets_path]) unless OS.unix?
         message = I18n.t("servicemanager.commands.env.docker.#{label}",
                          ip: options[:guest_ip], port: PORT, path: options[:secrets_path],

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -33,8 +33,7 @@ module Vagrant
       end
 
       def self.print_info(ui, options)
-        label = 'default'
-        label = 'script_readable' if options[:script_readable]
+        label = PluginUtil.env_label(options[:script_readable])
         message = I18n.t("servicemanager.commands.env.openshift.#{label}",
                          openshift_url: options[:url],
                          openshift_console_url: options[:console_url])

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -112,9 +112,21 @@ en:
             DOCKER_TLS_VERIFY=1
             DOCKER_API_VERSION=%{api_version}
         openshift:
-          default: |-
+          windows: |-
             # You can access the OpenShift console on: %{openshift_console_url}
             # To use OpenShift CLI, run: oc login %{openshift_url}
+            setx OPENSHIFT_URL %{openshift_url}
+            setx OPENSHIFT_WEB_CONSOLE %{openshift_console_url}
+          non_windows: |-
+            # You can access the OpenShift console on: %{openshift_console_url}
+            # To use OpenShift CLI, run: oc login %{openshift_url}
+            export OPENSHIFT_URL=%{openshift_url}
+            export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+          windows_cygwin: |-
+            # You can access the OpenShift console on: %{openshift_console_url}
+            # To use OpenShift CLI, run: oc login %{openshift_url}
+            export OPENSHIFT_URL=%{openshift_url}
+            export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
           script_readable: |-
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}


### PR DESCRIPTION
In conjuction with Issue #200 and PR #201 add environment
variables that output when requesting `env` without
`--script-readable`
