### PR TITLE
Fix #195: Acceptance tests based on Cucumber

### DIFF
--- a/.config/cucumber.yml
+++ b/.config/cucumber.yml
@@ -1,0 +1,12 @@
+# config/cucumber.yml
+##YAML Template
+---
+default: --profile html
+
+pretty: --format pretty -b
+html: --format progress --format html --out=build/features_report.html -b
+
+help: --tags @help --profile html
+box: --tags @box --profile html
+env: --tags @env --profile html
+openshift: --tags @openshift --profile html

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
+# Ruby, Bundler
 Gemfile.lock
-.vagrant
 .bundle
+.ruby-version
+.ruby-gemset
+
+# Vagrant
+.vagrant
+
+# Idea
+.idea
+*.iml
+
+# Build and tmp directories
+tmp
+build
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,16 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
-  # added as the vagrant component wouldn't build without it
-  gem 'json'
+  gem 'vagrant',      git: 'https://github.com/mitchellh/vagrant.git'
   gem 'rake'
-  gem 'bundler', '~> 1.6'
+  gem 'vagrant-libvirt'
+  gem 'fog-libvirt', '0.0.3' # https://github.com/pradels/vagrant-libvirt/issues/568
+  gem 'mechanize'
+  gem 'json'
+  gem 'cucumber', '~> 2.1'
+  gem 'aruba', '~> 0.13'
+  gem 'komenda', '~> 0.1.6'
+  gem 'launchy'
 end
 
 group :plugins do

--- a/README.md
+++ b/README.md
@@ -1,42 +1,45 @@
 # vagrant-service-manager
 
-* [Objective](#objective)
-* [How to Install the Plugin](#installation)
-* [Example Execution of the Plugin](#example_execution)
-* [Available Commands](#commands)
-* [Exit codes](#exit_codes)
-* [IP Address Detection](#ip_addr)
-* [Getting Involved with the Project](#Contributing)
+<!-- MarkdownTOC -->
+
+- [Objective](#objective)
+- [Installation](#installation)
+  - [Installing from a RubyGems](#installing-from-a-rubygems)
+  - [Installing from RPM](#installing-from-rpm)
+- [Usage](#usage)
+  - [Example execution of the plugin](#example-execution-of-the-plugin)
+  - [Available commands](#available-commands)
+  - [Exit codes](#exit-codes)
+  - [IP address detection](#ip-address-detection)
+- [Development](#development)
+  - [Setup](#setup)
+  - [Acceptance tests](#acceptance-tests)
+- [Getting involved](#getting-involved)
+
+<!-- /MarkdownTOC -->
 
 
+<a name="objective"></a>
+# Objective
 The vagrant-service-manager plugin is designed to enable easier access to the features and services provided by the [Atomic Developer Bundle (ADB)](https://github.com/projectatomic/adb-atomic-developer-bundle). It provides setup information, including environment variables and certificates, required to access services provided by the ADB and is a must have for most ADB users.
 
 This plugin makes it easier to use the ADB with host-based tools such as Eclipse and the docker and kubernetes CLI commands. Details on how to use ADB with this plugin can be found in the [ADB Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
 
-
-## Objective <a name="objective"></a>
-
-The [ADB](https://github.com/projectatomic/adb-atomic-developer-bundle) provides a ready-to-use development environment for container applications. With ADB, developers can dive right into producing complex, multi-container applications.
-
-The vagrant-service-manager provides the user with:
-
-* A CLI to configure the ADB for different use cases and to provide an interface between ADB and the user's development environment.
-* A tool to control and configure the ADB from the
-developer's workstation without having to `ssh` directly into the ADB virtual machine.
-
-
-## How to Install the Plugin <a name="installation"></a>
+<a name="installation"></a>
+# Installation
 
 The plugin is distributed as both a Ruby Gem and via RPM using the Fedora COPR system.
 
-### Installing from a Ruby Gem
+<a name="installing-from-a-rubygems"></a>
+## Installing from a RubyGems
 
-The [Ruby Gem](https://rubygems.org/gems/vagrant-service-manager) is
-available via the standard vagrant installation method:
+The vagrant-service-manager [gem](https://rubygems.org/gems/vagrant-service-manager) is available on [RubyGems](https://rubygems.org) and can be installed via the
+standard Vagrant plugin installation method:
 
     $ vagrant plugin install vagrant-service-manager
 
-### Installing from RPM
+<a name="installing-from-rpm"></a>
+## Installing from RPM
 
 The [Copr
 build](https://copr.fedorainfracloud.org/coprs/nshaikh/vagrant-service-manager/builds/)
@@ -45,21 +48,25 @@ is accessible via the standard COPR access/install method:
     $ dnf copr enable nshaikh/vagrant-service-manager
     $ dnf --enablerepo=nshaikh-vagrant-service-manager install vagrant-service-manager
 
-## Example Execution of the Plugin <a name="example_execution"></a>
+<a name="usage"></a>
+# Usage
+
+<a name="example-execution-of-the-plugin"></a>
+## Example execution of the plugin
 
 1. Install vagrant-service-manager plugin:
- 
+
         vagrant plugin install vagrant-service-manager
 
 2. Download the relevant Vagrantfile for your [ADB](https://github.com/projectatomic/adb-atomic-developer-bundle) vagrant box, from the [repository](https://github.com/projectatomic/adb-atomic-developer-bundle/tree/master/components/centos). For further details on the usage of custom Vagrantfiles designed for specific use cases, refer to the [Usage Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst).
 
 3. Start the ADB vagrant box using `vagrant up`. For detailed instructions consult the [Installation Documentation](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst).
 
-	**Note:** When the vagrant-service-manager plugin is loaded and a box is started using the VirtualBox provider, the user needs to add a routable non NAT network interface declaration in the Vagrantfile. If the user does not provide a network declaration in the Vagrantfile, a private DHCP network is added by default and a warning is displayed.
+  **Note:** When the vagrant-service-manager plugin is loaded and a box is started using the VirtualBox provider, the user needs to add a routable non NAT network interface declaration in the Vagrantfile. If the user does not provide a network declaration in the Vagrantfile, a private DHCP network is added by default and a warning is displayed.
 
 4. Run the plugin to get environment variables and certificates:
 
-        $ vagrant service-manager env docker       
+        $ vagrant service-manager env docker
         # Set the following environment variables to enable access to the
         # docker daemon running inside of the vagrant virtual machine:
         export DOCKER_HOST=tcp://172.28.128.4:2376
@@ -69,34 +76,35 @@ is accessible via the standard COPR access/install method:
         # run following command to configure your shell:
         # eval "$(vagrant service-manager env docker)"
 
-	**Note:** The required TLS certificates are copied to the host machine at the time of `vagrant up` itself. Every run of `vagrant service-manager env docker` checks for the validity of the certificates on the host machine by matching the certificates inside the box. If the certificates on the host machine are invalid, this command will also re-download the certificates onto the host machine.
+  **Note:** The required TLS certificates are copied to the host machine at the time of `vagrant up` itself. Every run of `vagrant service-manager env docker` checks for the validity of the certificates on the host machine by matching the certificates inside the box. If the certificates on the host machine are invalid, this command will also re-download the certificates onto the host machine.
 
 
-## Available Commands <a name="commands"></a>
+<a name="available-commands"></a>
+## Available commands
 
 The following section lists the available commands for the plugin and their explanation:
 
-1. `vagrant service-manager env [service] [--script-readable]` 
+1. `vagrant service-manager env [service] [--script-readable]`
 
    Displays connection information for all active services in the box in a manner that can be evaluated in a shell. If a `service` is specified, only the information for that service is displayed. When `--script-readable` is specified the output is in `key=value` format. The supported services are: Docker; OpenShift.
 
 2. `vagrant service-manager box [command]`
 
-   Displays box related information like release version, IP etc. 
+   Displays box related information like release version, IP etc.
 
 3. `vagrant service-manager box version [--script-readable]`
 
    Displays the version and release information of the running VM. When `--script-readable` is specified the output is in `key=value` format.
 
-4. `vagrant service-manager box ip` 
+4. `vagrant service-manager box ip`
 
-   Displays the routable IP address of the running VM. 
+   Displays the routable IP address of the running VM.
 
-5. `vagrant service-manager status [service]` 
+5. `vagrant service-manager status [service]`
 
    Lists services and their running state. If a `service` is specified only the status of that service is displayed. If no service is provided then only supported orchestrators are reported.
 
-6. `vagrant service-manager restart [service]` 
+6. `vagrant service-manager restart [service]`
 
    Restarts the given service in the box.
 
@@ -104,9 +112,8 @@ The following section lists the available commands for the plugin and their expl
 
    Displays the possible commands, options and other relevant information for the vagrant-service-manager plugin. If a `command` is specified, only the help relevant to that command is displayed.
 
-
-
-## Exit codes <a name="exit_codes"></a>
+<a name="exit-codes"></a>
+## Exit codes
 
 The following table lists the plugin's exit codes and their meaning:
 
@@ -118,15 +125,69 @@ Exit Code Number   | Meaning
 `126`              | A service inside the box is not running / Command invoked cannot execute
 
 
-## IP Address Detection <a name="ip_addr"></a>
+<a name="ip-address-detection"></a>
+## IP address detection
 
 There is no standardized way of detecting Vagrant box IP addresses.
 This code uses the last IPv4 address available from the set of configured addresses that are *up*.  i.e. if eth0, eth1, and eth2 are all up and have IPv4 addresses, the address on eth2 is used.
 
 
-## Getting Involved with the Project <a name="Contributing"></a>
+<a name="development"></a>
+# Development
 
-We welcome your input. You can submit issues or pull requests with respect to the vagrant-service-manager plugin. Refer to the [contributing guidelines](https://github.com/projectatomic/vagrant-service-manager/blob/master/CONTRIBUTING.md) for detailed information on how to contribute to this plugin.
+<a name="setup"></a>
+## Setup
+
+After cloning the repository, install the [Bundler](http://bundler.io/) gem:
+
+    $ gem install bundler
+
+Then setup your project dependencies:
+
+    $ bundle install
+
+The build is driven via rake. All build related tash should be executed in the
+Bundler environment, e.g. `bundle exec rake clean`. You can get a list of available
+Rake tasks via:
+
+    $ bundle exec rake -T
+
+<a name="acceptance-tests"></a>
+## Acceptance tests
+
+The source contains also a set of [Cucumber](https://cucumber.io/) acceptance tests. They can be run via:
+
+    $ bundle exec rake features
+
+The tests assume that the ADB and CDK box files are available under
+_build/boxes/adb-\<provider\>.box_ resp _build/boxes/cdk-\<provider\>.box_. You can
+either copy the box files manually or use the _get_adb_ resp. _get_cdk_ Rake tasks.
+
+Per default only the scenarios for ADB in combination with the VirtualBox provider are run. However, you can
+also run against CDK and/or use the Libvirt provider using the environment variables _BOX_ resp _PROVIDER_:
+
+    # Run tests against CDK using Libvirt
+    $ bundle exec rake features BOX=cdk PROVIDER=libvirt
+
+    # Run against ADB and CDK (boxes are comma seperated)
+    $ bundle exec rake features BOX=cdk,adb
+
+You can also run a single feature specifying the explicit feature file to use:
+
+    $ bundle exec rake features FEATURE=features/<feature-filename>.feature
+
+After test execution the Cucumber test reports can be found under _build/features_report.html_.
+They can also be opened via
+
+    $ bundle exec rake features:open_report
+
+<a name="getting-involved"></a>
+# Getting involved
+
+We welcome your input. You can submit issues or pull requests with respect to
+the vagrant-service-manager plugin. Refer to the
+[contributing guidelines](https://github.com/projectatomic/vagrant-service-manager/blob/master/CONTRIBUTING.md)
+for detailed information on how to contribute to this plugin.
 
 You can contact us on:
   * IRC: #atomic and #nulecule on freenode

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,91 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/clean'
+require 'cucumber/rake/task'
+require 'mechanize'
+require 'fileutils'
+require 'yaml'
+require 'launchy'
+
+CDK_DOWNLOAD_URL='https://access.redhat.com/downloads/content/293/ver=2/rhel---7/2.0.0/x86_64/product-software'
+CDK_BOX_BASE_NAME='rhel-cdk-kubernetes-7.2-23.x86_64.vagrant'
+
+ADB_DOWNLOAD_URL='http://cloud.centos.org/centos/7/atomic/images'
+ADB_BOX_BASE_NAME='AtomicDeveloperBundle-2.0.0-CentOS7'
+
+CLOBBER.include('pkg')
+CLEAN.include('build')
+
+task :init do
+  FileUtils.mkdir_p 'build'
+  puts ENV['FOO']
+end
+
+# Cucumber acceptance test tasks
+Cucumber::Rake::Task.new(:features)
+task :features => :init
+
+namespace :features do
+  desc 'Opens the HTML Cucumber test report'
+  task :open_report do
+    Launchy.open('./build/features_report.html')
+  end
+end
+
+desc 'Download CDK Vagrant box using the specified provider (default \'virtualbox\')'
+task :get_cdk, [:provider] do |t, args|
+  provider = args[:provider].nil? ? 'virtualbox' : args[:provider]
+  agent = Mechanize.new
+  agent.follow_meta_refresh = true
+  agent.get(CDK_DOWNLOAD_URL) do |page|
+
+    # Submit first form which is the redirect to login page form
+    login_page = page.forms.first.submit
+
+    # Submit the login form
+    after_login = login_page.form_with(:name => 'login_form') do |f|
+     username_field = f.field_with(:id => 'username')
+     username_field.value = 'service-manager@mailinator.com'
+     password_field = f.field_with(:id => 'password')
+     password_field.value = 'service-manager'
+    end.click_button
+
+    # There is one more redirect after successful login
+    download_page = after_login.forms.first.submit
+
+    download_page.links.each do |link|
+     if link.href =~ /#{Regexp.quote(CDK_BOX_BASE_NAME)}-#{Regexp.quote(provider)}.box/
+      download_dir = File.join(File.dirname(__FILE__), 'build', 'boxes')
+      unless File.directory?(download_dir)
+       FileUtils.mkdir_p(download_dir)
+      end
+      agent.pluggable_parser.default = Mechanize::Download
+      puts "Downloading #{link.href}"
+      agent.get(link.href).save(File.join(download_dir, "cdk-#{provider}.box"))
+     end
+    end
+  end
+end
+task :get_cdk => :init
+
+desc 'Download ADB Vagrant box using the specified provider (default \'virtualbox\')'
+task :get_adb, [:provider] do |t, args|
+  provider = args[:provider].nil? ? 'virtualbox' : args[:provider]
+  agent = Mechanize.new
+  agent.follow_meta_refresh = true
+  agent.get(ADB_DOWNLOAD_URL) do |page|
+    page.links.each do |link|
+      if match = link.href.match(/#{Regexp.quote(ADB_BOX_BASE_NAME)}-(.*).box/)
+        if  match.captures[0].downcase == provider
+          download_dir = File.join(File.dirname(__FILE__), 'build', 'boxes')
+          unless File.directory?(download_dir)
+            FileUtils.mkdir_p(download_dir)
+          end
+          agent.pluggable_parser.default = Mechanize::Download
+          puts "Downloading #{ADB_DOWNLOAD_URL}/#{link.href}"
+          agent.get(link.href).save(File.join(download_dir, "adb-#{provider}.box"))
+        end
+      end
+    end
+  end
+end
+task :get_adb => :init

--- a/features/box-command.feature
+++ b/features/box-command.feature
@@ -1,0 +1,45 @@
+Feature: Command output from box command
+  service-manager should return the correct output from box commands
+
+  @box
+  Scenario Outline: Boot and execute box commands
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    And I run `bundle exec vagrant service-manager box`
+    Then the exit status should be 1
+    And stdout from "bundle exec vagrant service-manager box" should contain:
+    """
+    Usage: vagrant service-manager box <sub-command> [options]
+
+    Sub-Command:
+          version    display version and release information about the running VM
+          ip         display routable IP address of the running VM
+
+    Options:
+          --script-readable  display information in a script readable format
+          -h, --help         print this help
+    """
+
+    When I successfully run `bundle exec vagrant service-manager box ip`
+    Then stdout from "bundle exec vagrant service-manager box ip" should contain "<ip>"
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |

--- a/features/env-command.feature
+++ b/features/env-command.feature
@@ -1,0 +1,52 @@
+Feature: Command output from env command
+  service-manager should return the correct output from env commands
+
+  @env
+  Scenario Outline: Boot and execute env commands
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    And I successfully run `bundle exec vagrant service-manager env`
+    Then stdout from "bundle exec vagrant service-manager env" should be evaluable in a shell
+
+    When I successfully run `bundle exec vagrant service-manager env --script-readable`
+    Then stdout from "bundle exec vagrant service-manager env --script-readable" should be script readable
+
+    When I successfully run `bundle exec vagrant service-manager env docker`
+    Then stdout from "bundle exec vagrant service-manager env docker" should be evaluable in a shell
+    And stdout from "bundle exec vagrant service-manager env docker" should contain "export DOCKER_HOST=tcp://<ip>:2376"
+    And stdout from "bundle exec vagrant service-manager env docker" should match /export DOCKER_CERT_PATH=.*\/.vagrant\/machines\/cdk\/virtualbox\/docker/
+    And stdout from "bundle exec vagrant service-manager env docker" should contain "export DOCKER_TLS_VERIFY=1"
+    And stdout from "bundle exec vagrant service-manager env docker" should contain "export DOCKER_API_VERSION=1.21"
+    And stdout from "bundle exec vagrant service-manager env docker" should match /# eval "\$\(vagrant service-manager env docker\)"/
+
+    When I successfully run `bundle exec vagrant service-manager env docker --script-readable`
+    Then stdout from "bundle exec vagrant service-manager env docker --script-readable" should be script readable
+
+    When I run `bundle exec vagrant service-manager env openshift`
+    Then the exit status should be 126
+    And stderr from "bundle exec vagrant service-manager env openshift" should contain:
+    """
+    # OpenShift service is not running in the vagrant box.
+    """
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |
+

--- a/features/help-command.feature
+++ b/features/help-command.feature
@@ -1,0 +1,80 @@
+Feature: Command output from help command
+  service-manager should return the correct output from its help commands
+
+  @help
+  Scenario Outline: Boot and execute help commands
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    And I successfully run `bundle exec vagrant service-manager --help`
+    Then stdout from "bundle exec vagrant service-manager --help" should contain:
+    """
+    Usage: vagrant service-manager <command> [options]
+
+    Commands:
+         env          displays connection information for services in the box
+         box          displays box related information like version, release, IP etc
+         restart      restarts the given systemd service in the box
+         status       list services and their running state
+
+    Options:
+         -h, --help   print this help
+
+    For help on any individual command run `vagrant service-manager COMMAND -h`
+    """
+
+    When I successfully run `bundle exec vagrant service-manager -h`
+    Then stdout from "bundle exec vagrant service-manager -h" should contain:
+    """
+    Usage: vagrant service-manager <command> [options]
+
+    Commands:
+         env          displays connection information for services in the box
+         box          displays box related information like version, release, IP etc
+         restart      restarts the given systemd service in the box
+         status       list services and their running state
+
+    Options:
+         -h, --help   print this help
+
+    For help on any individual command run `vagrant service-manager COMMAND -h`
+    """
+
+    When I run `bundle exec vagrant service-manager`
+    Then the exit status should be 1
+    And stdout from "bundle exec vagrant service-manager -h" should contain:
+    """
+    Usage: vagrant service-manager <command> [options]
+
+    Commands:
+         env          displays connection information for services in the box
+         box          displays box related information like version, release, IP etc
+         restart      restarts the given systemd service in the box
+         status       list services and their running state
+
+    Options:
+         -h, --help   print this help
+
+    For help on any individual command run `vagrant service-manager COMMAND -h`
+    """
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |
+

--- a/features/openshift.feature
+++ b/features/openshift.feature
@@ -1,0 +1,51 @@
+Feature: Command output from various OpenShift related commands
+  service-manager should return the correct output from commands affecting OpenShift
+
+  @openshift
+  Scenario Outline: Boot and execute commands
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+      config.vm.provision "shell", inline: <<-SHELL
+        systemctl enable openshift 2>&1
+        systemctl start openshift | true
+      SHELL
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    # TODO, for some reason I can not use 'successfully' here. Seems the exit code is not 0 in this case!?
+    And I run `bundle exec vagrant service-manager env openshift`
+    Then stdout from "bundle exec vagrant service-manager env openshift" should be evaluable in a shell
+    And stdout from "bundle exec vagrant service-manager env openshift" should contain:
+    """
+    # You can access the OpenShift console on: https://<ip>:8443/console
+    # To use OpenShift CLI, run: oc login https://<ip>:8443
+    export OPENSHIFT_URL=https://<ip>:8443
+    export OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
+
+    # run following command to configure your shell:
+    # eval "$(vagrant service-manager env openshift)"
+    """
+
+    When I successfully run `bundle exec vagrant service-manager env openshift --script-readable`
+    Then stdout from "bundle exec vagrant service-manager env openshift --script-readable" should be script readable
+    And stdout from "bundle exec vagrant service-manager env openshift --script-readable" should contain:
+    """
+    OPENSHIFT_URL=https://<ip>:8443
+    OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
+    """
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |

--- a/features/status-command.feature
+++ b/features/status-command.feature
@@ -1,0 +1,31 @@
+Feature: Command output from status command
+  service-manager should return the correct output from status command
+
+  @status
+  Scenario Outline: Boot and execute status command
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    And I successfully run `bundle exec vagrant service-manager status`
+    Then stdout from "bundle exec vagrant service-manager status" should contain "docker - running"
+    Then stdout from "bundle exec vagrant service-manager status" should contain "openshift - stopped"
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,83 @@
+require 'aruba/cucumber'
+require 'komenda'
+
+###############################################################################
+# Aruba config and Cucumber hooks
+###############################################################################
+
+Aruba.configure do |config|
+  config.exit_timeout = 300
+  config.activate_announcer_on_command_failure = [:stdout, :stderr]
+  config.working_directory = 'build/aruba'
+end
+
+After do |_scenario|
+  if File.exist?(File.join(aruba.config.working_directory, 'Vagrantfile'))
+    Komenda.run('bundle exec vagrant destroy -f', cwd: aruba.config.working_directory, fail_on_fail: true)
+    if ENV.has_key?('CUCUMBER_RUN_PROVIDER')
+      # if we have more than one provider we need to wait between scenarios in order to allow for proper cleanup/shutdown
+      # of virtualization framework
+      sleep 10
+    end
+  end
+end
+
+Before do |scenario|
+  @scenario_name = scenario.name
+end
+
+###############################################################################
+# Some helper functions
+###############################################################################
+# When running Vagrant from within a plugin development environment, Vagrant
+# prints a warning which we can ignore
+def stdout_without_plugin_context(raw_stdout)
+  raw_stdout.lines.to_a[6..-1].join
+end
+
+def output_is_evaluable(raw_stdout)
+  console_out = stdout_without_plugin_context(raw_stdout)
+  console_out.each_line do |line|
+    expect(line).to match(/^#.*|^export [a-zA-Z_]+=.*|^\n/)
+  end
+end
+
+def output_is_script_readable(raw_stdout)
+  console_out = stdout_without_plugin_context(raw_stdout)
+  console_out.each_line do |line|
+    expect(line).to match(/^[a-zA-Z_]+=.*$/)
+  end
+end
+
+###############################################################################
+# Some shared step definitions
+##############################################################################
+Given /provider is (.*)/ do |current_provider|
+  requested_provider =  ENV.has_key?('PROVIDER') ? ENV['PROVIDER']: 'virtualbox'
+
+  unless requested_provider.include?(current_provider)
+    #puts "Skipping scenario '#{@scenario_name}' for provider '#{current_provider}', since this provider is not explicitly enabled via environment variable 'PROVIDER'"
+    skip_this_scenario
+  end
+end
+
+Given /box is (.*)/ do |current_box|
+  requested_box =  ENV.has_key?('BOX') ? ENV['BOX']: 'adb'
+
+  unless requested_box.include?(current_box)
+    #puts "Skipping scenario '#{@scenario_name}' for box '#{current_box}', since this box is not explicitly enabled via environment variable 'BOX'"
+    skip_this_scenario
+  end
+end
+
+Then(/^stdout from "([^"]*)" should be evaluable in a shell$/) do |cmd|
+  output_is_evaluable(aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout))
+end
+
+Then(/^stdout from "([^"]*)" should be script readable$/) do |cmd|
+  output_is_script_readable(aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout))
+end
+
+Then(/^stdout from "([^"]*)" should match \/(.*)\/$/) do |cmd, regexp|
+  aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout)  =~ /#{regexp}/
+end


### PR DESCRIPTION
To execute the Cucumber tests:

```
$ bundle install
$ bundle exec rake get_adb
$ bundle exec rake get_cdk
$ bundle exec rake features 
```

Reports in _build/features_report.html_.

Alternatively one can manually copy the box files to the expected directory (see README)

I switched from vagrant-spec to Cucumber, since the former seems to be lest maintained and the syntax and reporting of Cucumber/Gherkin is much better.

Thoughts?
