### PR TITLE
CHANGELOG fix and README update for OS support for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Updated README to make Installation Instructions clearer @bexelbie
+- Fix #195 Adding Cucumber and Aruba based acceptance tests @hferentschik
+- CHANGELOG fix and README update for OS support for tests @budhrg
 
 ## v1.0.2 May 09, 2016
 - Add --script-readable to env and env docker @bexelbie
 - Fix #178: Add status command and separate status from env @bexelbie
-- Fix#173: Shows if kubernetes services is running in the box @navidshaikh
+- Fix #173: Shows if kubernetes services is running in the box @navidshaikh
 - Fix #169: Adds command for displaying box routable IP address @navidshaikh
 - Fix message for box command on default help @budhrg
 - Fix #184: Make env headers comments for vagrant service-manager env @bexelbie
@@ -16,7 +19,6 @@
 - Fix #200: Simplify the eval hint for `vagrant service-manager env` command @budhrg
 - Add environment variables for Openshift env output @bexelbie
 - Fix #181: vagrant-service-manager version 1.0.2 release @navidshaikh
-- Updated README to make Installation Instructions clearer @bexelbie
 
 ## v1.0.1 Apr 12, 2016
 - Updated SPEC (v1.0.0) for url, date and format @budhrg

--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ Rake tasks via:
 <a name="acceptance-tests"></a>
 ## Acceptance tests
 
-The source contains also a set of [Cucumber](https://cucumber.io/) acceptance tests. They can be run via:
+The source also contains a set of [Cucumber](https://cucumber.io/) acceptance tests. They can be run via:
 
     $ bundle exec rake features
+
+_NOTE_: Only Linux OS is supported at present.
 
 The tests assume that the ADB and CDK box files are available under
 _build/boxes/adb-\<provider\>.box_ resp _build/boxes/cdk-\<provider\>.box_. You can


### PR DESCRIPTION
- Fix `CHANGELOG` updates
- Added note for supported OS for `Acceptance tests`.
