### PR TITLE
Fix #168: Extend --debug flag to show plugin activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - CHANGELOG fix and README update for OS support for tests @budhrg
 - Fix #188: Name of k8s service not consistent @budhrg
 - Fix #225: service-manager env throws NameError @budhrg
+- Fix #168: Extend --debug flag to show plugin activity @budhrg
 
 ## v1.0.2 May 09, 2016
 - Add --script-readable to env and env docker @bexelbie

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ The following section lists the available commands for the plugin and their expl
 
    Displays the possible commands, options and other relevant information for the vagrant-service-manager plugin. If a `command` is specified, only the help relevant to that command is displayed.
 
+#### Debug Flag
+
+  Append `--debug` flag to enable debug mode.
+
+  *Note* : Debug output from `vagrant-service-manager` is prepended with the following string:
+  ```
+  DEBUG command: [ service-manager: <command name / log message> ]
+  ```
 <a name="exit-codes"></a>
 ## Exit codes
 

--- a/features/debug-flag.feature
+++ b/features/debug-flag.feature
@@ -1,0 +1,30 @@
+Feature: Command output from --debug flag
+  service-manager should print the debug logs along with native logs
+
+  @status
+  Scenario Outline: Boot and execute simple env command with debug logs
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    And I successfully run `bundle exec vagrant service-manager env --debug`
+    Then stdout from "bundle exec vagrant service-manager env --debug" should match /DEBUG command: [ service-manager: env ]/
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -79,5 +79,5 @@ Then(/^stdout from "([^"]*)" should be script readable$/) do |cmd|
 end
 
 Then(/^stdout from "([^"]*)" should match \/(.*)\/$/) do |cmd, regexp|
-  aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout)  =~ /#{regexp}/
+  aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout) =~ /#{regexp}/
 end

--- a/lib/vagrant-service-manager.rb
+++ b/lib/vagrant-service-manager.rb
@@ -8,7 +8,7 @@ require 'vagrant-service-manager/plugin'
 require 'vagrant-service-manager/command'
 require 'vagrant-service-manager/os'
 
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     # Returns the path to the source of this plugin
     def self.source_root

--- a/lib/vagrant-service-manager/action/setup_network.rb
+++ b/lib/vagrant-service-manager/action/setup_network.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     module Action
       class SetupNetwork

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -1,6 +1,6 @@
 require 'set'
 
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     SERVICES = ['docker', 'openshift']
     CONFIG_KEYS  = [

--- a/lib/vagrant-service-manager/plugin.rb
+++ b/lib/vagrant-service-manager/plugin.rb
@@ -2,7 +2,7 @@
 Dir["#{File.dirname(__FILE__)}/action/*.rb"].each { |f| require_relative f }
 require_relative 'service'
 
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     class Plugin < Vagrant.plugin('2')
       name "service-manager"

--- a/lib/vagrant-service-manager/plugin_logger.rb
+++ b/lib/vagrant-service-manager/plugin_logger.rb
@@ -1,0 +1,32 @@
+module VagrantPlugins
+  module PluginLogger
+    @debug = false
+
+    def self.debug_mode?
+      @debug
+    end
+
+    def self.logger
+      @logger
+    end
+
+    def self.enable_debug_mode
+      @debug = true
+    end
+
+    def self.set_logger(logger)
+      @logger = logger
+    end
+
+    def self.command
+      (ARGV.drop(1) - ['--debug', '--script-readable']).join(' ')
+    end
+
+    def self.debug(message = nil)
+      if debug_mode?
+        message = "#{command}" if message.nil?
+        logger.debug "[ service-manager: #{message} ]"
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/service.rb
+++ b/lib/vagrant-service-manager/service.rb
@@ -1,7 +1,7 @@
 # Loads all services
 Dir["#{File.dirname(__FILE__)}/services/*.rb"].each { |f| require_relative f }
 
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     SUPPORTED_BOXES = ['adb', 'cdk']
 

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     class Docker
       # Hard Code the Docker port because it is fixed on the VM
@@ -42,6 +42,7 @@ module Vagrant
             docker_api_version_cmd.gsub!(/APIVersion/, 'ApiVersion')
           end
 
+          PluginLogger.debug
           machine.communicate.execute(docker_api_version_cmd) do |type, data|
             options[:api_version] = data.chomp if type == :stdout
           end
@@ -56,6 +57,8 @@ module Vagrant
       end
 
       def self.print_env_info(ui, options)
+        PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
+
         label = PluginUtil.env_label(options[:script_readable])
         options[:secrets_path] = PluginUtil.windows_path(options[:secrets_path]) unless OS.unix?
         message = I18n.t("servicemanager.commands.env.docker.#{label}",

--- a/lib/vagrant-service-manager/services/kubernetes.rb
+++ b/lib/vagrant-service-manager/services/kubernetes.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     class Kubernetes
       def initialize(machine, ui)

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     class OpenShift
       OPENSHIFT_PORT = 8443
@@ -11,7 +11,7 @@ module Vagrant
 
       def execute
         command = "#{@extra_cmd} sccli openshift"
-        Plugin.execute_and_exit_on_fail(@machine, @ui, command)
+        PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
       end
 
       def self.status(machine, ui, service)
@@ -33,6 +33,8 @@ module Vagrant
       end
 
       def self.print_info(ui, options)
+        PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
+
         label = PluginUtil.env_label(options[:script_readable])
         message = I18n.t("servicemanager.commands.env.openshift.#{label}",
                          openshift_url: options[:url],

--- a/lib/vagrant-service-manager/version.rb
+++ b/lib/vagrant-service-manager/version.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module ServiceManager
     VERSION = "1.0.2"
   end

--- a/plugins/guests/redhat/cap/box_version.rb
+++ b/plugins/guests/redhat/cap/box_version.rb
@@ -3,17 +3,19 @@ module VagrantPlugins
     module Cap
       class BoxVersion
         # Prints the version of the vagrant box, parses /etc/os-release for version
-        def self.box_version(machine, script_readable)
+        def self.box_version(machine, options = {})
           command = "cat #{OS_RELEASE_FILE} | grep VARIANT"
+
           # TODO: execute efficient command to solve this
           if machine.communicate.test(command) # test if command is exits with code 0
+            PluginLogger.debug
             machine.communicate.execute(command) do |type, data|
               if type == :stderr
                 @env.ui.error(data)
                 exit 126
               end
 
-              return data.chomp if script_readable
+              return data.chomp if options[:script_readable]
               info = Hash[data.delete('"').split("\n").map { |e| e.split('=') }]
               return "#{info['VARIANT']} #{info['VARIANT_VERSION']}"
             end

--- a/plugins/guests/redhat/cap/machine_ip.rb
+++ b/plugins/guests/redhat/cap/machine_ip.rb
@@ -6,9 +6,12 @@ module VagrantPlugins
           # Find the guest IP
           command = "ip -o -4 addr show up |egrep -v ': docker|: lo' |tail -1 | awk '{print $4}' |cut -f1 -d\/"
           ip = ''
+
+          PluginLogger.debug
           machine.communicate.execute(command) do |type, data|
             ip << data.chomp if type == :stdout
           end
+
           ip
         end
       end

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -1,4 +1,5 @@
 require 'vagrant'
+require File.expand_path('../../../../', __FILE__) + '/lib/vagrant-service-manager/plugin_logger'
 
 module VagrantPlugins
   OS_RELEASE_FILE = '/etc/os-release'

--- a/vagrant-service-manager.gemspec
+++ b/vagrant-service-manager.gemspec
@@ -3,7 +3,7 @@ require 'vagrant-service-manager/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'vagrant-service-manager'
-  spec.version       = Vagrant::ServiceManager::VERSION
+  spec.version       = VagrantPlugins::ServiceManager::VERSION
   spec.license       = 'GPL-2.0'
   spec.homepage      = 'https://github.com/projectatomic/vagrant-service-manager'
   spec.summary       = "To provide the user a CLI to configure the ADB/CDK for different use cases and to provide glue between ADB/CDK and the user's developer environment."


### PR DESCRIPTION
Fixes #168 
    \* **MAJOR CHANGE**: Migrated namespace from 'Vagrant' to 'VagrantPlugins'
    \* Debug mode for plugin can be enabled using --debug flag at the end of the command.
    \* Debug log start with `DEBUG command: [ service-manager: <command name or message> ]`
    \* Added acceptance test

Example debug logs for command `$ vagrant service-manager restart openshift --debug`:

```
......
DEBUG ssh: == Net-SSH connection debug-level log END ==
 INFO ssh: Execute: sccli openshift (sudo=true)
DEBUG ssh: stdout: Stopping the Openshift services

DEBUG command: [ service-manager: restart openshift ]
DEBUG ssh: stderr: Removed symlink /etc/systemd/system/multi-user.target.wants/openshift.service.

DEBUG ssh: stdout: Trying to pull repository registry.access.redhat.com/openshift3/ose ... 
DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: stdout: b863f26a99f7: Pulling image (v3.1.1.6) from registry.access.redhat.com/openshift3/ose
b863f26a99f7: Pulling image (v3.1.1.6) from registry.access.redhat.com/openshift3/ose, endpoint: https://registry.access.redhat.com/v1/

DEBUG ssh: stdout: b863f26a99f7: Pulling dependent layers
c453594215e4: Download complete

DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: stdout: d565afadcc73: Download complete
b863f26a99f7: Download complete

DEBUG ssh: stdout: Status: Image is up to date for registry.access.redhat.com/openshift3/ose:v3.1.1.6
registry.access.redhat.com/openshift3/ose: this image was pulled from a legacy registry.  Important: This registry version will not be supported in future versions of docker.

DEBUG ssh: stdout: Trying to pull repository registry.access.redhat.com/openshift3/ose-haproxy-router ... 
DEBUG ssh: Sending SSH keep-alive...
......
```
