### PR TITLE
Add "start" as an alias for "restart"

### DIFF
--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -102,7 +102,7 @@ module Vagrant
           else
             print_help(type: command, exit_status: 1)
           end
-        when 'restart'
+        when 'restart', 'start'
           exit_if_machine_not_running
           case subcommand
           when '--help', '-h'


### PR DESCRIPTION
This allows some instructions and concepts to "read" better.

Helps with https://github.com/projectatomic/adb-atomic-developer-bundle/pull/386
