### PR TITLE
Fix #172: Implement "start/enable" service command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix #168: Extend --debug flag to show plugin activity @budhrg
 - Don't set private network for unsupported box @budhrg
 - Convert CONTRIBUTING and README docs to AsciiDoc @bexelbie
+- Fix #172: Implement "start/enable" service command @budhrg
 
 ## v1.0.2 May 09, 2016
 - Add --script-readable to env and env docker @bexelbie

--- a/README.adoc
+++ b/README.adoc
@@ -136,9 +136,15 @@ Lists services and their running state. If a `service` is specified only
 the status of that service is displayed. If no service is provided then
 only supported orchestrators are reported.
 
-1.  `vagrant service-manager restart [service]`
+1.  `vagrant service-manager [operation] [service]`
 +
-Restarts the given service in the box.
+where `operation` could be:
+
+  * `restart` : Restart the given service in the box.
+  * `start`   : Start the given service in the box.
+  * `stop`    : Stop the given service in the box.
++
+and `service` could be `docker`, `openshift`, `kubernetes` etc.
 
 1.  `vagrant service-manager [command] [--help | -h]`
 +

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ CDK_DOWNLOAD_URL='https://access.redhat.com/downloads/content/293/ver=2/rhel---7
 CDK_BOX_BASE_NAME='rhel-cdk-kubernetes-7.2-23.x86_64.vagrant'
 
 ADB_DOWNLOAD_URL='http://cloud.centos.org/centos/7/atomic/images'
-ADB_BOX_BASE_NAME='AtomicDeveloperBundle-2.0.0-CentOS7'
+ADB_BOX_BASE_NAME='AtomicDeveloperBundle-2.1.0-CentOS7'
 
 CLOBBER.include('pkg')
 CLEAN.include('build')

--- a/features/env-command.feature
+++ b/features/env-command.feature
@@ -49,4 +49,3 @@ Feature: Command output from env command
       | adb   | virtualbox | 10.10.10.42 |
       | cdk   | libvirt    | 10.10.10.42 |
       | adb   | libvirt    | 10.10.10.42 |
-

--- a/features/help-command.feature
+++ b/features/help-command.feature
@@ -27,7 +27,9 @@ Feature: Command output from help command
     Commands:
          env          displays connection information for services in the box
          box          displays box related information like version, release, IP etc
-         restart      restarts the given systemd service in the box
+         restart      restarts the given service in the box
+         start        starts the given service in the box
+         stop         stops the given service in the box
          status       list services and their running state
 
     Options:
@@ -44,7 +46,9 @@ Feature: Command output from help command
     Commands:
          env          displays connection information for services in the box
          box          displays box related information like version, release, IP etc
-         restart      restarts the given systemd service in the box
+         restart      restarts the given service in the box
+         start        starts the given service in the box
+         stop         stops the given service in the box
          status       list services and their running state
 
     Options:
@@ -62,7 +66,9 @@ Feature: Command output from help command
     Commands:
          env          displays connection information for services in the box
          box          displays box related information like version, release, IP etc
-         restart      restarts the given systemd service in the box
+         restart      restarts the given service in the box
+         start        starts the given service in the box
+         stop         stops the given service in the box
          status       list services and their running state
 
     Options:

--- a/features/service-operation.feature
+++ b/features/service-operation.feature
@@ -1,0 +1,40 @@
+Feature: Command output from service operations like stop/start/restart
+  service-manager should return the correct exit code from stop/start/restart command
+
+  @operation
+  Scenario Outline: Boot and execute service operations like stop/start/restart
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    require 'vagrant-libvirt'
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+      config.servicemanager.services = 'docker'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+      When the "docker" service is running
+      When I successfully run `bundle exec vagrant service-manager stop docker`
+      Then the service "docker" should be stopped
+
+      When the "docker" service is not running
+      And I successfully run `bundle exec vagrant service-manager start docker`
+      Then the service "docker" should be running
+
+      When the "docker" service is running
+      And I successfully run `bundle exec vagrant service-manager restart docker`
+      Then the service "docker" should be running
+      And have a new pid for "docker" service
+
+    Examples:
+      | box   | provider   | ip          |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | adb   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -63,17 +63,8 @@ module VagrantPlugins
         running_services
       end
 
-      def self.kube_running?(machine)
-        KUBE_SERVICES.each do |service|
-          return false unless service_running?(machine, service)
-        end
-        true
-      end
-
       def self.service_running?(machine, service)
-        return kube_running?(machine) if service == 'kubernetes'
-        command = "systemctl status #{service}"
-        PluginLogger.debug
+        command = "sudo sccli #{service} status"
         machine.communicate.test(command)
       end
 
@@ -99,6 +90,8 @@ module VagrantPlugins
         end
 
         exit_code
+      rescue StandardError => e
+        ui.error e.message.squeeze
       end
 
       def self.print_shell_configure_info(ui, command = '')

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,7 +24,9 @@ en:
           Commands:
                env          displays connection information for services in the box
                box          displays box related information like version, release, IP etc
-               restart      restarts the given systemd service in the box
+               restart      restarts the given service in the box
+               start        starts the given service in the box
+               stop         stops the given service in the box
                status       list services and their running state
 
           Options:
@@ -69,20 +71,20 @@ en:
 
           Example:
                 vagrant service-manager status openshift
-        restart: |-
-          Restarts the service
+        operation: |-
+          %{operation}s the service
 
-          Usage: vagrant service-manager restart <service> [options]
+          Usage: vagrant service-manager %{operation} <service> [options]
 
           Service:
-              A service provided by sccli or systemd. For example:
-               docker, k8s, or openshift etc.
+              A service provided by sccli. For example:
+               docker, kubernetes, openshift etc
 
           Options:
                 -h, --help         print this help
 
           Examples:
-            vagrant service-manager restart docker
+            vagrant service-manager %{operation} docker
 
       env:
         docker:
@@ -139,8 +141,11 @@ en:
           # eval "$(vagrant service-manager env%{command})"
         service_not_running: |-
           # %{name} service is not running in the vagrant box.
-      restart:
+      operation:
         service_missing: 'Service name missing'
+        sccli_only_support: |-
+          Only sccli services are supported. For example:
+            docker, openshift and kubernetes
 
       status:
         nil: |-


### PR DESCRIPTION
Fix #172.
- Mapped `start/stop/restart/status` commands with
  `sccli`(https://github.com/projectatomic/adb-utils/blob/master/utils/sccli.py)
- Added `stop` operation
- Removed support of `systemd` services. Only sccli services are
  supported
- Updated implementation of `status` as per `sccli`
- Added acceptance tests
- Updated message if service name is missing
- Updated help messages
