### PR TITLE
Bypass hook if no supported guest/box found

### DIFF
--- a/lib/vagrant-service-manager/service.rb
+++ b/lib/vagrant-service-manager/service.rb
@@ -30,6 +30,8 @@ module Vagrant
             @openshift_hook.execute
           end
         end
+      rescue Vagrant::Errors::GuestCapabilityNotFound
+        # Do nothing if supported box variant not found
       end
     end
   end


### PR DESCRIPTION
Fix #220
- Plugin should not interface other box/os behavior
