### PR TITLE
Fix #225: service-manager env throws NameError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix #195 Adding Cucumber and Aruba based acceptance tests @hferentschik
 - CHANGELOG fix and README update for OS support for tests @budhrg
 - Fix #188: Name of k8s service not consistent @budhrg
+- Fix #225: service-manager env throws NameError @budhrg
 
 ## v1.0.2 May 09, 2016
 - Add --script-readable to env and env docker @bexelbie

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -150,11 +150,11 @@ module Vagrant
 
           running_service_classes.each do |service_class|
             service = service_class.to_s.split('::').last.downcase
-            unless options[:script_readable] || KUBE_NAMES.include?(service)
+            unless options[:script_readable] || service == 'kubernetes'
               @env.ui.info("\n# #{service} env:")
             end
             # since we do not have feature to show the Kube connection information
-            unless KUBE_NAMES.include? service
+            unless service == 'kubernetes'
               service_class.info(machine, @env.ui, options)
             end
           end

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -70,7 +70,7 @@ module Vagrant
       end
 
       def self.service_running?(machine, service)
-        return kube_running?(machine) if KUBE_NAMES.include? service
+        return kube_running?(machine) if service == 'kubernetes'
         command = "systemctl status #{service}"
         machine.communicate.test(command)
       end


### PR DESCRIPTION
Fix #225.

Removed unwanted constant `KUBE_NAMES` which possibly got reversed in git rebase.
Tests are passing now.
