### PR TITLE
Fix #210: Adds docker registry URL in openshift env info

### DIFF
--- a/features/openshift.feature
+++ b/features/openshift.feature
@@ -36,6 +36,7 @@ Feature: Command output from various OpenShift related commands
     # To use OpenShift CLI, run: oc login https://<ip>:8443
     export OPENSHIFT_URL=https://<ip>:8443
     export OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
+    export DOCKER_REGISTRY=hub.openshift.rhel-cdk.<ip>.xip.io
 
     # run following command to configure your shell:
     # eval "$(vagrant service-manager env openshift)"
@@ -47,6 +48,25 @@ Feature: Command output from various OpenShift related commands
     """
     OPENSHIFT_URL=https://<ip>:8443
     OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
+    DOCKER_REGISTRY=hub.openshift.rhel-cdk.<ip>.xip.io
+    """
+
+    When I successfully run `bundle exec vagrant service-manager env`
+    Then stdout from "bundle exec vagrant service-manager env" should contain "export DOCKER_HOST=tcp://<ip>:2376"
+    And stdout from "bundle exec vagrant service-manager env" should match /export DOCKER_CERT_PATH=.*\/.vagrant\/machines\/cdk\/virtualbox\/docker/
+    And stdout from "bundle exec vagrant service-manager env" should contain "export DOCKER_TLS_VERIFY=1"
+    And stdout from "bundle exec vagrant service-manager env" should contain "export DOCKER_API_VERSION=1.21"
+    And stdout from "bundle exec vagrant service-manager env" should match /# eval "\$\(vagrant service-manager env\)"/
+    And stdout from "bundle exec vagrant service-manager env" should contain:
+    """
+    # openshift env:
+    # You can access the OpenShift console on: https://<ip>:8443/console
+    # To use OpenShift CLI, run: oc login https://<ip>:8443
+    export OPENSHIFT_URL=https://<ip>:8443
+    export OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
+    export DOCKER_REGISTRY=hub.openshift.rhel-cdk.<ip>.xip.io
+    # run following command to configure your shell:
+    # eval "$(vagrant service-manager env)"
     """
 
     Examples:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -120,19 +120,23 @@ en:
             # To use OpenShift CLI, run: oc login %{openshift_url}
             setx OPENSHIFT_URL %{openshift_url}
             setx OPENSHIFT_WEB_CONSOLE %{openshift_console_url}
+            setx DOCKER_REGISTRY %{docker_registry}
           non_windows: |-
             # You can access the OpenShift console on: %{openshift_console_url}
             # To use OpenShift CLI, run: oc login %{openshift_url}
             export OPENSHIFT_URL=%{openshift_url}
             export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            export DOCKER_REGISTRY=%{docker_registry}
           windows_cygwin: |-
             # You can access the OpenShift console on: %{openshift_console_url}
             # To use OpenShift CLI, run: oc login %{openshift_url}
             export OPENSHIFT_URL=%{openshift_url}
             export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            export DOCKER_REGISTRY=%{docker_registry}
           script_readable: |-
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            DOCKER_REGISTRY=%{docker_registry}
         windows_cygwin_configure_info: |-
             # run following command to configure your shell:
             # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env%{command} | tr -d '\r')"


### PR DESCRIPTION
Fixes #210 

```
➜  vagrant-service-manager git:(fix-210) ✗ vagrant service-manager env openshift
# You can access the OpenShift console on: https://10.1.2.2:8443/console
# To use OpenShift CLI, run: oc login https://10.1.2.2:8443
export OPENSHIFT_URL=https://10.1.2.2:8443
export OPENSHIFT_WEB_CONSOLE=https://10.1.2.2:8443/console
export DOCKER_REGISTRY=hub.openshift.rhel-cdk.10.1.2.2.xip.io

# run following command to configure your shell:
# eval "$(vagrant service-manager env openshift)"
```
