### PR TITLE
Fix #252: Added --script-readable option to box ip

### DIFF
--- a/features/box-command.feature
+++ b/features/box-command.feature
@@ -41,6 +41,9 @@ Feature: Command output from box command
     When I successfully run `bundle exec vagrant service-manager box ip`
     Then stdout from "bundle exec vagrant service-manager box ip" should contain "<ip>"
 
+    When I successfully run `bundle exec vagrant service-manager box ip --script-readable`
+    Then stdout from "bundle exec vagrant service-manager box ip --script-readable" should be script readable
+
     Examples:
       | box   | provider   | ip          |
       | cdk   | virtualbox | 10.10.10.42 |

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -100,6 +100,8 @@ module VagrantPlugins
             case option
             when nil
               display_box_ip
+            when '--script-readable'
+              display_box_ip(true)
             when '--help', '-h'
               print_help(type: command)
             else
@@ -202,9 +204,11 @@ module VagrantPlugins
         end
       end
 
-      def display_box_ip
+      def display_box_ip(script_readable = false)
+        options = { script_readable: script_readable }
+
         with_target_vms(nil, single_target: true) do |machine|
-          @env.ui.info machine.guest.capability(:machine_ip)
+          @env.ui.info machine.guest.capability(:machine_ip, options)
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -58,8 +58,9 @@ en:
 
           Examples:
                 vagrant service-manager box version
-                vagrant service-manager box ip
                 vagrant service-manager box version --script-readable
+                vagrant service-manager box ip
+                vagrant service-manager box ip --script-readable
         status: |-
           Usage: vagrant service-manager status [service] [options]
 

--- a/plugins/guests/redhat/cap/machine_ip.rb
+++ b/plugins/guests/redhat/cap/machine_ip.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestRedHat
     module Cap
       class MachineIP
-        def self.machine_ip(machine)
+        def self.machine_ip(machine, options = {})
           # Find the guest IP
           command = "ip -o -4 addr show up |egrep -v ': docker|: lo' |tail -1 | awk '{print $4}' |cut -f1 -d\/"
           ip = ''
@@ -10,6 +10,7 @@ module VagrantPlugins
           PluginLogger.debug
           machine.communicate.execute(command) do |type, data|
             ip << data.chomp if type == :stdout
+            return "IP=#{ip}" if options[:script_readable]
           end
 
           ip


### PR DESCRIPTION
Fix #252. Output in the form of:

```
$ vagrant service-manager box ip --script-readable
IP=<ip>
```

Examples:

```
      vagrant service-manager box version
      vagrant service-manager box version --script-readable
      vagrant service-manager box ip
      vagrant service-manager box ip --script-readable
```
