### PR TITLE
[WIP] Fix #90: Add install-cli command

### DIFF
--- a/lib/vagrant-service-manager.rb
+++ b/lib/vagrant-service-manager.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
 
     # Temporally load the extra capabilities files for Red Hat
     load(File.join(source_root, 'plugins/guests/redhat/plugin.rb'))
+    # Load the host capabilities files
+    ['linux', 'darwin'].each do |host|
+      load(File.join(source_root, "plugins/hosts/#{host}/plugin.rb"))
+    end
     # Default I18n to load the en locale
     I18n.load_path << File.expand_path("locales/en.yml", source_root)
   end

--- a/lib/vagrant-service-manager/adb_installer.rb
+++ b/lib/vagrant-service-manager/adb_installer.rb
@@ -1,0 +1,92 @@
+module VagrantPlugins
+  module ServiceManager
+    VERSION_CMD = {
+      docker: "docker version --format '{{.Server.Version}}'",
+      openshift: "oc version | grep 'oc' | grep -oE '[0-9.]+'"
+    }
+
+    class ADBInstaller < Installer
+      # Refer https://docs.docker.com/v1.10/engine/installation/binaries
+      DOCKER_BINARY_BASE_URL = 'https://get.docker.com/builds'
+
+      OC_BINARY_BASE_URL = 'https://github.com/openshift/origin/releases'
+      OC_FILE_PREFIX = 'openshift-origin-client-tools'
+
+      def initialize(type, machine, env, options)
+        super(type, machine, env, options)
+      end
+
+      def build_download_url
+        arch = @machine.env.host.capability(:os_arch)
+        @url = "#{DOCKER_BINARY_BASE_URL}/#{docker_os_type}/#{arch}/docker-#{@version}#{docker_ext}"
+      end
+
+      def ensure_binary_and_temp_directories
+        bin_dir = File.dirname(@path)
+        FileUtils.mkdir_p(bin_dir) unless File.directory?(bin_dir)
+        Dir.mkdir(@temp_bin_dir) unless File.directory?(@temp_bin_dir)
+      end
+
+      def download_and_prepare_binary
+        archive_file_name = File.basename(@url)
+        Vagrant::Util::Downloader.new(@url, "#{@temp_bin_dir}/#{archive_file_name}").download!
+        archive_dir_name = archive_file_name.gsub('.tgz|.tar.gz|.zip', '')
+        puts "archive_file_name: #{archive_file_name}"
+        puts "archive_dir_name: #{archive_dir_name}"
+        puts "url: #{@url}, path : #{@path}"
+        # Steps to download binary
+        # open zip/tar file and read particular binary and copy it and then exit
+        # FileUtils.cp("#{@temp_bin_dir}/#{archive_dir_name}/#{@binary_name}", @path)
+      end
+
+      def docker_os_type
+        if OS.windows?
+          'Windows'
+        elsif OS.unix?
+          'Linux'
+        elsif OS.mac?
+          'Darwin'
+        end
+      end
+
+      def docker_ext
+        OS.windows? ? '.zip' : '.tgz'
+      end
+
+      def openshift_binary_download_url
+        arch = @machine.env.host.capability(:os_arch)
+        download_base_path = "#{OC_BINARY_BASE_URL}/download/v#{@version}/"
+        file = "#{OC_FILE_PREFIX}-v#{@version}-#{version_sha}-#{ext}"
+        download_base_path + file
+      end
+
+      def version_sha
+        require 'net/http'
+
+        tag_url =  "#{OC_BINARY_BASE_URL}/tag/v#{@version}"
+        data = Net::HTTP.get(URI(tag_url))
+        tokens = data.match("-v#{@version}-(.*)-#{ext}").captures
+        tokens.first unless tokens.empty?
+      end
+
+      def oc_os_type
+        if OS.windows?
+          'windows'
+        elsif OS.linux?
+          'linux'
+        elsif OS.mac?
+          'mac'
+        end
+      end
+
+      def arch
+        arch = @machine.env.host.capability(:os_arch)
+        arch == 'x86_64' ? '64' : '32'
+      end
+
+      def ext
+        oc_os_type + (oc_os_type == 'linux' ? "-#{arch}bit.tar.gz" : ".zip")
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/archive_handler.rb
+++ b/lib/vagrant-service-manager/archive_handler.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module ServiceManager
+    class ArchiveHandler
+      def executor(file, dest)
+        @executor =  case File.extname(file)
+                     when '.tgz', '.tar.gz' then TarExecutor.new(file, dest)
+                     when '.zip' then ZipExecutor.new(file, dest)
+                     end
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/cdk_installer.rb
+++ b/lib/vagrant-service-manager/cdk_installer.rb
@@ -1,0 +1,9 @@
+module VagrantPlugins
+  module ServiceManager
+    class CDKInstaller
+      def execute
+        # TODO
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/installer.rb
+++ b/lib/vagrant-service-manager/installer.rb
@@ -1,0 +1,55 @@
+module VagrantPlugins
+  module ServiceManager
+    class Installer
+      LABEL = 'servicemanager.commands.install_cli.message'
+      TEMP_DIR = '/tmp'
+      BINARY_NAME = {
+        docker: 'docker', openshift: 'oc'
+      }
+
+      def initialize(type, machine, env, options)
+        @type = type
+        @machine = machine
+        @ui = env.ui
+        @options = options
+
+        @binary_exists = true
+        @version = options['--cli-version'] || PluginUtil.execute_once(@machine, @ui, VERSION_CMD[@type])
+        @path = options['--path']
+        @binary_name = BINARY_NAME[@type]
+        @temp_bin_dir = "#{TEMP_DIR}/#{@type.to_s}"
+        @url = ''
+      end
+
+      def install
+        puts "I m install now...."
+        build_binary_path
+
+        unless PluginUtil.binary_downloaded?(@path)
+          build_download_url
+          puts "url: #{@url}"
+          ensure_binary_and_temp_directories
+          download_and_prepare_binary
+        end
+      end
+
+      def print_message
+        @ui.info I18n.t(LABEL, path: @path, dir: File.dirname(@path),
+                        binary: @binary_name, when: (@binary_exists ? 'already' : 'now'))
+      end
+
+      def build_binary_path
+        @path = "#{ServiceManager.bin_dir}/#{@type.to_s}/#{@version}/#{@binary_name}" if @path.nil?
+      end
+
+      def build_download_url
+      end
+
+      def ensure_binary_and_temp_directories
+      end
+
+      def download_and_prepare_binary
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/installer_helpers.rb
+++ b/lib/vagrant-service-manager/installer_helpers.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module ServiceManager
+    module DockerInstaller
+    end
+
+    module DockerInstaller
+    end
+
+    module DockerInstaller
+    end
+  end
+end

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -94,6 +94,15 @@ module VagrantPlugins
         ui.error e.message.squeeze
       end
 
+      def self.execute_once(machine, ui, command)
+        machine.communicate.sudo(command) do |type, data|
+          PluginLogger.debug
+          return data.chomp
+        end
+      rescue StandardError => e
+        ui.error e.message.squeeze
+      end
+
       def self.print_shell_configure_info(ui, command = '')
         label = if OS.unix?
                   'unix_configure_info'
@@ -116,6 +125,10 @@ module VagrantPlugins
         else
           'windows'
         end
+      end
+
+      def self.binary_downloaded?(path)
+        File.file?(path)
       end
     end
   end

--- a/lib/vagrant-service-manager/service.rb
+++ b/lib/vagrant-service-manager/service.rb
@@ -1,3 +1,4 @@
+require_relative 'service_base'
 # Loads all services
 Dir["#{File.dirname(__FILE__)}/services/*.rb"].each { |f| require_relative f }
 

--- a/lib/vagrant-service-manager/service_base.rb
+++ b/lib/vagrant-service-manager/service_base.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module ServiceManager
+    class ServiceBase
+      def initialize(machine, env)
+        @machine = machine
+        @env = machine.env
+        @ui = @env.ui
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/services/kubernetes.rb
+++ b/lib/vagrant-service-manager/services/kubernetes.rb
@@ -1,20 +1,20 @@
 module VagrantPlugins
   module ServiceManager
-    class Kubernetes
-      def initialize(machine, ui)
-        @machine = machine
-        @ui = ui
+    class Kubernetes < ServiceBase
+      def initialize(machine, env)
+        super(machine, env)
+        @service_name = 'kubernetes'
       end
 
       def execute
         # TODO: Implement execute method
       end
 
-      def self.status(machine, ui, service)
-        PluginUtil.print_service_status(ui, machine, service)
+      def status
+        PluginUtil.print_service_status(@ui, @machine, @service_name)
       end
 
-      def self.info(machine, ui, options = {})
+      def info(options = {})
         # TODO: Implement info method
       end
     end

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -1,11 +1,11 @@
 module VagrantPlugins
   module ServiceManager
-    class OpenShift
-      OPENSHIFT_PORT = 8443
+    class OpenShift < ServiceBase
+      PORT = 8443
 
-      def initialize(machine, ui)
-        @machine = machine
-        @ui = ui
+      def initialize(machine, env)
+        super(machine, env)
+        @service_name = 'openshift'
         @extra_cmd = build_extra_command
       end
 
@@ -14,49 +14,22 @@ module VagrantPlugins
         PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
       end
 
-      def self.status(machine, ui, service)
-        PluginUtil.print_service_status(ui, machine, service)
+      def status
+        PluginUtil.print_service_status(@ui, @machine, @service_name)
       end
 
-      def self.docker_registry_host(machine)
-        url = ''
-        PluginLogger.debug
-        command = \
-          "sudo oc --config=/var/lib/openshift/openshift.local." +
-          "config/master/admin.kubeconfig get route/docker-registry " +
-          "-o template --template={{.spec.host}}"
-        machine.communicate.execute(command) do |type, data|
-          url << data.chomp if type == :stdout
-        end
-        url
-      end
-
-      def self.info(machine, ui, options = {})
+      def info(options = {})
         options[:script_readable] ||= false
 
-        if PluginUtil.service_running?(machine, 'openshift')
-          options[:url] = "https://#{PluginUtil.machine_ip(machine)}:#{OPENSHIFT_PORT}"
+        if PluginUtil.service_running?(@machine, 'openshift')
+          options[:url] = "https://#{PluginUtil.machine_ip(@machine)}:#{PORT}"
           options[:console_url] = "#{options[:url]}/console"
-          options[:docker_registry] = docker_registry_host(machine)
-          print_info(ui, options)
+          options[:docker_registry] = docker_registry_host
+          print_info(options)
         else
-          ui.error I18n.t('servicemanager.commands.env.service_not_running',
+          @ui.error I18n.t('servicemanager.commands.env.service_not_running',
                           name: 'OpenShift')
           exit 126
-        end
-      end
-
-      def self.print_info(ui, options)
-        PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
-
-        label = PluginUtil.env_label(options[:script_readable])
-        message = I18n.t("servicemanager.commands.env.openshift.#{label}",
-                         openshift_url: options[:url],
-                         openshift_console_url: options[:console_url],
-                         docker_registry: options[:docker_registry])
-        ui.info(message)
-        unless options[:script_readable] || options[:all]
-          PluginUtil.print_shell_configure_info(ui, ' openshift')
         end
       end
 
@@ -71,6 +44,35 @@ module VagrantPlugins
           end
         end
         cmd.chop
+      end
+
+      def print_info(options)
+        PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
+
+        label = PluginUtil.env_label(options[:script_readable])
+        message = I18n.t("servicemanager.commands.env.openshift.#{label}",
+                         openshift_url: options[:url],
+                         openshift_console_url: options[:console_url],
+                         docker_registry: options[:docker_registry])
+        @ui.info(message)
+
+        unless options[:script_readable] || options[:all]
+          PluginUtil.print_shell_configure_info(@ui, ' openshift')
+        end
+      end
+
+      def docker_registry_host
+        url = ''
+        PluginLogger.debug
+        command = \
+          "sudo oc --config=/var/lib/openshift/openshift.local." +
+          "config/master/admin.kubeconfig get route/docker-registry " +
+          "-o template --template={{.spec.host}}"
+
+        @machine.communicate.execute(command) do |type, data|
+          url << data.chomp if type == :stdout
+        end
+        url
       end
     end
   end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -86,6 +86,20 @@ en:
 
           Examples:
             vagrant service-manager %{operation} docker
+        install_cli: |-
+          Install the client side tool for the service
+
+          Usage: vagrant service-manager install-cli [service] [options]
+
+          Service:
+              A service provided by sccli. For example:
+               docker, kubernetes, openshift etc
+
+          Options:
+                -h, --help         print this help
+
+          Example:
+                vagrant service-manager install-cli docker
 
       env:
         docker:
@@ -151,6 +165,17 @@ en:
         sccli_only_support: |-
           Only sccli services are supported. For example:
             docker, openshift and kubernetes
+
+      install_cli:
+        message: |-
+          # Binary %{when} available at %{path}
+
+          # run following command to configure your shell:
+          # export PATH=%{dir}:$PATH
+
+          # run binary as:
+          # %{binary} <command>
+        unsupported_box: Sorry, client binaries for CDK are not supported yet.
 
       status:
         nil: |-

--- a/plugins/hosts/darwin/cap/os_arch.rb
+++ b/plugins/hosts/darwin/cap/os_arch.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HostDarwin
+    module Cap
+      class OSArch
+        def self.os_arch(env)
+          `uname -m`.chop
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/darwin/plugin.rb
+++ b/plugins/hosts/darwin/plugin.rb
@@ -1,0 +1,13 @@
+require 'vagrant'
+
+module VagrantPlugins
+  module HostDarwin
+    class Plugin < Vagrant.plugin('2')
+      host_capability('darwin', 'os_arch') do
+        require_relative 'cap/os_arch'
+
+        Cap::OSArch
+      end
+    end
+  end
+end

--- a/plugins/hosts/linux/cap/os_arch.rb
+++ b/plugins/hosts/linux/cap/os_arch.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HostLinux
+    module Cap
+      class OSArch
+        def self.os_arch(env)
+          `uname -m`.chop
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/linux/plugin.rb
+++ b/plugins/hosts/linux/plugin.rb
@@ -1,0 +1,13 @@
+require 'vagrant'
+
+module VagrantPlugins
+  module HostLinux
+    class Plugin < Vagrant.plugin('2')
+      host_capability('linux', 'os_arch') do
+        require_relative 'cap/os_arch'
+
+        Cap::OSArch
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix #90 
_Only linux supported at present._

Example execution:

```
$ bundle exec vagrant service-manager install-cli docker
# Binary now available at /home/budhram/.vagrant.d/data/service-manager/bin/docker/1.9.1/docker

# run following command to configure your shell:
# export PATH=/home/budhram/.vagrant.d/data/service-manager/bin/docker/1.9.1:$PATH

# run binary as:
# docker <command>

$ export PATH=/home/budhram/.vagrant.d/data/service-manager/bin/docker/1.9.1:$PATH

$ docker version
Client:
 Version:      1.9.1
 API version:  1.21
 Go version:   go1.4.3
 Git commit:   a34a1d5
 Built:        Fri Nov 20 17:56:04 UTC 2015
 OS/Arch:      linux/amd64
Cannot connect to the Docker daemon. Is the docker daemon running on this host?

$ bundle exec vagrant service-manager install-cli docker                          
# Binary already available at /home/budhram/.vagrant.d/data/service-manager/bin/docker/1.9.1/docker

# run following command to configure your shell:
# export PATH=/home/budhram/.vagrant.d/data/service-manager/bin/docker/1.9.1:$PATH

# run binary as:
# docker <command>
```

Few points to note:
- One can use system binary by **opening a new terminal tab/window**.
- In last command, 'already' word is written for same version of binary
- Added `--path` to specify destination binary path
- Added `--cli-version` to specify binary version. `--version` conflicting with vagrant `--version` flag.

Not adding `--url` as it is very tricky and have no control over user's input.
