### PR TITLE
Fix #268 Explicitly setting v1.8.4 as dev version for Vagrant. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,12 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant',      git: 'https://github.com/mitchellh/vagrant.git'
+  gem 'vagrant',
+      :git => 'git://github.com/mitchellh/vagrant.git',
+      :ref => 'v1.8.4'
   gem 'rake'
-  gem 'vagrant-libvirt'  if RUBY_PLATFORM =~ /linux/i
-  gem 'fog-libvirt', '0.0.3'  if RUBY_PLATFORM =~ /linux/i # https://github.com/pradels/vagrant-libvirt/issues/568
+  gem 'vagrant-libvirt'              if RUBY_PLATFORM =~ /linux/i
+  gem 'fog-libvirt', '0.0.3'         if RUBY_PLATFORM =~ /linux/i # https://github.com/pradels/vagrant-libvirt/issues/568
   gem 'mechanize'
   gem 'json'
   gem 'cucumber', '~> 2.1'


### PR DESCRIPTION
HEAD of Vagrant 1.8.4.dev has switched to use Ruvy 2.2 (2 days ago, see https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec). I don't think we should follow suite as yet.
