### PR TITLE
Fix #278: Acceptance tests for --help option for commands

### DIFF
--- a/features/box-command.feature
+++ b/features/box-command.feature
@@ -38,6 +38,27 @@ Feature: Command output from box command
           -h, --help         print this help
     """
 
+    When I successfully run `bundle exec vagrant service-manager box --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager box --help" should contain:
+    """
+    Usage: vagrant service-manager box <sub-command> [options]
+
+    Sub-Command:
+          version    display version and release information about the running VM
+          ip         display routable IP address of the running VM
+
+    Options:
+          --script-readable  display information in a script readable format
+          -h, --help         print this help
+
+    Examples:
+          vagrant service-manager box version
+          vagrant service-manager box version --script-readable
+          vagrant service-manager box ip
+          vagrant service-manager box ip --script-readable
+    """
+
     When I successfully run `bundle exec vagrant service-manager box ip`
     Then stdout from "bundle exec vagrant service-manager box ip" should contain "<ip>"
 

--- a/features/env-command.feature
+++ b/features/env-command.feature
@@ -23,7 +23,24 @@ Feature: Command output from env command
     """
 
     When I successfully run `bundle exec vagrant up --provider <provider>`
-    And I successfully run `bundle exec vagrant service-manager env`
+    And I successfully run `bundle exec vagrant service-manager env --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager env --help" should contain:
+    """
+    Usage: vagrant service-manager env [object] [options]
+
+    Objects:
+          docker      display information and environment variables for docker
+          openshift   display information and environment variables for openshift
+
+    If OBJECT is omitted, display the information for all active services
+
+    Options:
+          --script-readable  display information in a script readable format.
+          -h, --help         print this help
+    """
+
+    When I successfully run `bundle exec vagrant service-manager env`
     Then stdout from "bundle exec vagrant service-manager env" should be evaluable in a shell
 
     When I successfully run `bundle exec vagrant service-manager env --script-readable`

--- a/features/service-operation.feature
+++ b/features/service-operation.feature
@@ -23,7 +23,80 @@ Feature: Command output from service operations like stop/start/restart
     """
 
     When I successfully run `bundle exec vagrant up --provider <provider>`
-    And I successfully run `bundle exec vagrant service-manager status`
+    And I successfully run `bundle exec vagrant service-manager status --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager status --help" should contain:
+    """
+    Usage: vagrant service-manager status [service] [options]
+
+    Options:
+          -h, --help         print this help
+
+    If a service is provided, only that service is reported.
+    If no service is provided only supported orchestrators are reported.
+
+    Example:
+          vagrant service-manager status openshift
+    """
+
+    And I successfully run `bundle exec vagrant service-manager stop --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager stop --help" should contain:
+    """
+    stops the service
+
+    Usage: vagrant service-manager stop <service> [options]
+
+    Service:
+        A service provided by sccli. For example:
+         docker, kubernetes, openshift etc
+
+    Options:
+          -h, --help         print this help
+
+    Examples:
+      vagrant service-manager stop docker
+    """
+
+    And I successfully run `bundle exec vagrant service-manager start --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager start --help" should contain:
+    """
+    starts the service
+
+    Usage: vagrant service-manager start <service> [options]
+
+    Service:
+        A service provided by sccli. For example:
+         docker, kubernetes, openshift etc
+
+    Options:
+          -h, --help         print this help
+
+    Examples:
+      vagrant service-manager start docker
+    """
+
+    And I successfully run `bundle exec vagrant service-manager restart --help`
+    Then the exit status should be 0
+    And stdout from "bundle exec vagrant service-manager restart --help" should contain:
+    """
+    restarts the service
+
+    Usage: vagrant service-manager restart <service> [options]
+
+    Service:
+        A service provided by sccli. For example:
+         docker, kubernetes, openshift etc
+
+    Options:
+          -h, --help         print this help
+
+    Examples:
+      vagrant service-manager restart docker
+    """
+
+    When I successfully run `bundle exec vagrant service-manager status`
     Then stdout from "bundle exec vagrant service-manager status" should contain "docker - running"
     Then stdout from "bundle exec vagrant service-manager status" should contain "openshift - stopped"
     Then stdout from "bundle exec vagrant service-manager status" should contain "kubernetes - stopped"


### PR DESCRIPTION
like box, env and service-operations

Fix #278
