### PR TITLE
Fix #302: support proxy env variables

### DIFF
--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -5,7 +5,8 @@ module VagrantPlugins
     SERVICES = ['docker', 'openshift']
     CONFIG_KEYS  = [
       :services, :openshift_docker_registry,
-      :openshift_image_name, :openshift_image_tag
+      :openshift_image_name, :openshift_image_tag,
+      :openshift_proxy, :openshift_proxy_user, :openshift_proxy_password
     ]
 
     class Config < Vagrant.plugin('2', :config)

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
       end
 
       def execute
-        command = "#{@extra_cmd} sccli openshift"
+        command = "#{@extra_cmd} sccli openshift start"
         PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
       end
 


### PR DESCRIPTION
Fix #302 .

Adding configurations to openshift as:

```
config.servicemanager.openshift_docker_registry = 'docker.io'
config.servicemanager.openshift_image_name = 'openshift/origin'
config.servicemanager.openshift_image_tag = 'v1.1.1'
config.servicemanager.openshift_proxy = '10.70.49.109:3128'
config.servicemanager.openshift_proxy_user = 'fedora'
config.servicemanager.openshift_proxy_password = 'fedora123'
config.servicemanager.services = 'openshift'
```

will generate respective `sccli` command as

```
DOCKER_REGISTRY='docker.io' IMAGE_NAME='openshift/origin' IMAGE_TAG='v1.1.1' PROXY='10.70.49.109:3128' PROXY_USER='fedora' PROXY_PASSWORD='fedora123' sccli openshift start
```

This is dependent on the PR https://github.com/projectatomic/adb-utils/pull/150 and need to merged after PR `adb-utils#150` got merged.
