### PR TITLE
Fix #312: message for kubernetes install-cli

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,20 +127,17 @@ If existing certificates are found to be invalid, they get regenerated.
 +
 Displays box related information like release version, IP etc.
 +
---
 The possible options for `command` are:
 
 * `version`: Displays the version and release information of the running VM.
 * `ip`: Displays the routable IP address of the running VM.
 +
---
 When `--script-readable` is specified the output is in `key=value` format.
 
 1.  `vagrant service-manager [operation] [service]`
 +
 Manages the life cycle of a service.
 +
---
 The possible options for `operation` are:
 
   * `status`: Lists services and their running state. If a `service` is specified only
@@ -150,10 +147,18 @@ only supported orchestrators are reported.
   * `stop`: Stop the given service in the box.
   * `restart`: Restart the given service in the box.
 +
---
 The supported options for `service` are: Docker, OpenShift.
 
+1. `vagrant service-manager install-cli [service] [--cli-version] [--path]`
++
+Install the client binary for the specified `service`.
++
+The possible options are:
 
+  * `--cli-version`: Download the binary in the specified version, if it exist.
+  * `--path`: Download the binary to the specified path on the host.
++
+The supported options for `service` are: Docker, OpenShift.
 
 [[debug-flag]]
 ==== Debug Flag

--- a/lib/vagrant-service-manager/installer.rb
+++ b/lib/vagrant-service-manager/installer.rb
@@ -33,6 +33,11 @@ module VagrantPlugins
           exit 126
         end
 
+        if @type == :kubernetes
+          @env.ui.info I18n.t('servicemanager.commands.install_cli.kube_not_supported')
+          exit 126
+        end
+
         unless PluginUtil.service_running?(@machine, @type.to_s)
           @env.ui.info I18n.t('servicemanager.commands.install_cli.service_not_enabled',
                               service: @type)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -186,6 +186,8 @@ en:
           Please visit access.redhat.com to download client binaries.
         service_not_enabled: |-
           '%{service}' service is not enabled.
+        kube_not_supported: |-
+          Installation of Kubernetes client library via the install-cli command is not supported yet.
 
       status:
         nil: |-

--- a/test/vagrant-service-manager/installer_test.rb
+++ b/test/vagrant-service-manager/installer_test.rb
@@ -71,6 +71,17 @@ module VagrantPlugins
           @installer.instance_variable_get('@binary_handler').binary_exists.must_equal true
         end
       end
+
+      describe 'Kubernetes' do
+        before do
+          @type = :kubernetes
+          @options = { box_version: 'adb' }
+        end
+
+        it 'should exit' do
+          assert_raises(SystemExit) { @installer = Installer.new(@type, @machine, @machine.env, @options) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #312 

Since, kubernetes access from host is not supported at present hence we are showing warning for respective install-cli command. 
