### PR TITLE
Fix #197 Created new doc for available commands with examples.

### DIFF
--- a/Commands.adoc
+++ b/Commands.adoc
@@ -1,0 +1,244 @@
+= Available Commands and Examples
+:toc:
+:toc-placement!:
+
+Once you `vagrant up` and have a running VM, the vagrant-service-manager
+ enables you to check and tweak your container development environment.
+
+'''
+toc::[]
+'''
+
+You can use the vagrant-service-manager to set up your environment variables and
+ get the TLS certificates to secure the Docker communication channel; identify
+ the routable ip address and version of your VM; and check the status and
+ manage the lifecycle of the configured services in the running VM.
+
+To run the vagrant-service-manager plugin use: +
+-------------------------------------------
+vagrant service-manager [command] [options]
+-------------------------------------------
+The following commands can be used: +
+
+`env`::  Displays the connection information for services in the VM +
+`box`:: Displays the VM related information like version, release, IP etc +
+`status`:: Lists services and their running state +
+`start`:: Starts the given service in the VM +
+`stop`:: Stops the given service in the VM +
+`restart`:: Restarts the given service in the VM +
+
+The following options can be used: +
+
+`--script-readable`:: Displays information in a key=value format +
+`-h, --help`:: Prints help for the specific command being run +
+
+
+== Get Environment Variables and Certificates
+
+If you need to get the environment variables and certificates for all the active
+ services in the VM, run: +
+
+`$ vagrant service-manager env` +
+
+Usage: `vagrant service-manager env [service] [options]`
+
+The possible options for service are `docker` and `openshift`. +
+If no service is specified `vagrant service-manager env` provides connection
+ information for all the active services.
+
+The following options can be used: +
+
+`--script-readable`:: Displays information in a key=value format +
+`-h, --help`:: Prints help for the specific command being run. +
+
+=== Examples
+
+If you need connection information for all active services in the VM, in a
+manner that can be evaluated in a shell, use:
+-----------------------------------------------------------------------------
+$ vagrant service-manager env
+
+# docker env:
+# Set the following environment variables to enable access to the
+# docker daemon running inside of the vagrant virtual machine:
+export DOCKER_HOST=tcp://10.1.2.2:2376
+export DOCKER_CERT_PATH=/foo/bar/.vagrant/machines/default/virtualbox/docker
+export DOCKER_TLS_VERIFY=1
+export DOCKER_API_VERSION=1.21
+
+# openshift env:
+# You can access the OpenShift console on: https://10.1.2.2:8443/console
+# To use OpenShift CLI, run: oc login https://10.1.2.2:8443
+export OPENSHIFT_URL=https://10.1.2.2:8443
+export OPENSHIFT_WEB_CONSOLE=https://10.1.2.2:8443/console
+export DOCKER_REGISTRY=hub.openshift.centos7-adb.10.1.2.2.xip.io
+
+# run following command to configure your shell:
+# eval "$(vagrant service-manager env)"
+-----------------------------------------------------------------------------
+
+If you need to run the plugin and get the environment variables and
+certificates for a specific service, use: +
+For Docker:
+----------------------------------------------------------------------------
+$ vagrant service-manager env docker
+# Set the following environment variables to enable access to the
+# docker daemon running inside of the vagrant virtual machine:
+export DOCKER_HOST=tcp://172.28.128.3:2376
+export DOCKER_CERT_PATH=/foo/bar/.vagrant/machines/default/virtualbox/docker
+export DOCKER_TLS_VERIFY=1
+export DOCKER_API_VERSION=1.21
+
+# run following command to configure your shell:
+# eval "$(vagrant service-manager env docker)"
+----------------------------------------------------------------------------
+
+*Note:* In the case of the `docker` service, the required TLS certificates for
+securing the Docker communication will be regenerated and copied to the host
+as part of the command execution. If existing certificates are found to be
+invalid, they get regenerated.
+
+Similarly, for OpenShift you can use: +
+`$ vagrant service-manager env openshift`
+
+If you want to run the plugin and get the environment variables and certificates
+ for docker in key=value format, use:
+----------------------------------------------------------------------
+$ vagrant service-manager env docker --script-readable
+DOCKER_HOST=tcp://172.28.128.3:2376
+DOCKER_CERT_PATH=/foo/bar/.vagrant/machines/default/virtualbox/docker'
+DOCKER_TLS_VERIFY=1
+DOCKER_API_VERSION=1.21
+----------------------------------------------------------------------
+
+
+== Identify IP Address and Version of the VM
+
+If you need to find information related to the VM, such as the routable
+IP address or the version and release information of the VM image, use:
+
+`$ vagrant service-manager box` +
+
+Usage: `vagrant service-manager box [sub-command] [options]`
+
+The following sub-commands can be used: +
+
+`ip`:: Displays the routable IP address of the VM +
+`version`:: Displays the version and release information of the VM +
+
+The following options can be used: +
+
+`--script-readable`:: Displays information in a key=value format +
+`-h, --help`:: Prints help for the specific command being run.
+
+=== Examples
+
+To check the routable IP address of the VM:
+---------------------------------
+$ vagrant service-manager box ip
+172.28.128.3
+---------------------------------
+
+To check the routable IP address of the VM in key=value format:
+---------------------------------------------------
+$ vagrant service-manager box ip --script-readable
+IP=172.28.128.3
+---------------------------------------------------
+
+To check the version of the VM:
+--------------------------------------
+$ vagrant service-manager box version
+Atomic Developer Bundle (ADB) 2.2.0
+--------------------------------------
+
+To check the version of the VM in key=value format:
+--------------------------------------------------------
+$ vagrant service-manager box version --script-readable
+VARIANT="Atomic Developer Bundle (ADB)"
+VARIANT_ID="adb"
+VARIANT_VERSION="2.2.0"
+--------------------------------------------------------
+
+
+== Manage Service Lifecycles
+
+If you need to mange the lifecycle of a service - check the current status of
+services, start or stop or restart a specific service use: +
+`$ vagrant service-manager [sub-command] [service]`
+
+The following sub-commands can be used: +
+
+`status`::   Lists services and their state (running/stopped) +
+`start`::   Starts the given service in the VM +
+`stop`::   Stops the given service in the VM +
+`restart`::   Restarts the given service in the VM +
+
+The possible options for service are `docker`, `openshift` and `kubernetes`.
+
+=== Examples
+
+If no service is specified `vagrant service-manager status` will provide
+information on all the configured services and their state (running/stopped).
+---------------------------------------
+$ vagrant service-manager status
+Configured services:
+docker - stopped
+openshift - running
+kubernetes - stopped
+---------------------------------------
+
+To check the status of Docker:
+-------------------------------------------
+$ vagrant service-manager status docker
+docker - stopped
+-------------------------------------------
+
+To start Docker:
+---------------------------------------------
+$ vagrant service-manager start docker
+$ vagrant service-manager status docker
+docker - running
+---------------------------------------------
+
+To stop Docker:
+---------------------------------------------
+$ vagrant service-manager stop docker
+$ vagrant service-manager status docker
+docker - stopped
+---------------------------------------------
+
+To restart Docker:
+-----------------------------------------
+$ vagrant service-manager restart docker
+$ vagrant service-manager status docker
+docker - running
+-----------------------------------------
+
+Similarly, you can use `$ vagrant service-manager status openshift`,
+ `$ vagrant service-manager start openshift`, `$ vagrant service-manager stop openshift`,
+ and `$ vagrant service-manager restart openshift`, to verify the status, start,
+  stop and restart OpenShift.
+
+== Use the Help 
+If you need information on the possible commands, options and other relevant
+information for the vagrant-service-manager plugin, access the help for using
+the vagrant-service-manager plugin with:
+
+--------------------------------------------------------------------------------
+$ vagrant service-manager [--help | -h]
+Usage: vagrant service-manager <command> [options]
+
+The following commands can be used:
+env: displays connection information for services in the VM
+box: displays VM related information like version, release, IP etc
+status: lists services and their running state
+start: starts the given service in the VM
+stop: stops the given service in the VM
+restart: restarts the given service in the VM
+
+The following options can be used:
+--script-readable : Displays information in a key=value format
+-h, --help   print this help
+
+For help on any individual command run `vagrant service-manager <command> -h`
+--------------------------------------------------------------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ instructions consult the
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst[Installation
 Documentation].
 +
-*Note:* When the vagrant-service-manager plugin is loaded and an ADB box is
+NOTE: When the vagrant-service-manager plugin is loaded and an ADB box is
 started using the VirtualBox provider, the user needs to add a routable
 non NAT network interface declaration in the Vagrantfile. If the user
 does not provide a network declaration in the Vagrantfile, a private
@@ -94,80 +94,50 @@ export DOCKER_API_VERSION=1.20
 # eval "$(vagrant service-manager env docker)"
 ----------------------------------------------------------------------------
 +
-*Note:* The required TLS certificates are copied to the host machine at
+NOTE: The required TLS certificates are copied to the host machine at
 the time of `vagrant up` itself. Every run of
 `vagrant service-manager env docker` checks for the validity of the
 certificates on the host machine by matching the certificates inside the
-box. If the certificates on the host machine are invalid, this command
+VM. If the certificates on the host machine are invalid, this command
 will also re-download the certificates onto the host machine.
 
 === Available commands
 
-The following section lists the available commands for the plugin and
-their explanation:
+The following section lists the high level commands available for the plugin,
+which enable you to:
 
-1.  `vagrant service-manager [command] [--help | -h]`
-+
+- set up your environment variables and get the TLS certificates to secure the
+Docker communication channel;
+- identify the routable ip address as well as the version of your VM;
+- and manage the lifecycle of the configured services.
+
+For a detailed list of all available commands and their explanations refer
+ to the <<Commands.adoc#, Commands Document>>.
+
+.  `vagrant service-manager [command] [--help | -h]` +
 Displays the possible commands, options and other relevant information
-for the vagrant-service-manager plugin. If a `command` is specified,
-only the help relevant to that command is displayed.
+for the vagrant-service-manager plugin.
 
-1.  `vagrant service-manager env [service] [--script-readable]`
-+
-Displays connection information for all active services in the box in a
-manner that can be evaluated in a shell. +
-If a `service` is specified, only the information for that service is displayed.
-The supported services are: Docker, OpenShift. +
-When `--script-readable` is specified the output is in `key=value` format. +
-In the case of the _docker_ service, the required TLS certificates for securing the Docker
-communication will be regenerated and copied to the host as part of the command execution.
-If existing certificates are found to be invalid, they get regenerated.
+.  `vagrant service-manager env [service] [--script-readable]` +
+Displays connection information for all active services in the VM, in a
+manner that can be evaluated in a shell.
 
-1.  `vagrant service-manager box [command] [--script-readable]`
-+
-Displays box related information like release version, IP etc.
-+
-The possible options for `command` are:
+.  `vagrant service-manager box [command] [--script-readable]` +
+Displays VM related information like release version, IP, etc.
 
-* `version`: Displays the version and release information of the running VM.
-* `ip`: Displays the routable IP address of the running VM.
-+
-When `--script-readable` is specified the output is in `key=value` format.
-
-1.  `vagrant service-manager [operation] [service]`
-+
+.  `vagrant service-manager [operation] [service]` +
 Manages the life cycle of a service.
-+
-The possible options for `operation` are:
 
-  * `status`: Lists services and their running state. If a `service` is specified only
-the status of that service is displayed. If no service is provided then
-only supported orchestrators are reported.
-  * `start`: Start the given service in the box.
-  * `stop`: Stop the given service in the box.
-  * `restart`: Restart the given service in the box.
-+
-The supported options for `service` are: Docker, OpenShift.
-
-1. `vagrant service-manager install-cli [service] [--cli-version] [--path]`
-+
-Install the client binary for the specified `service`.
-+
-The possible options are:
-
-  * `--cli-version`: Download the binary in the specified version, if it exists.
-  * `--path`: Download the binary to the specified path on the host.
-+
-The supported options for `service` are: Docker, OpenShift.
+. `vagrant service-manager install-cli [service] [--cli-version] [--path]` +
+Installs the client binary for the specified service.
 
 [[debug-flag]]
 ==== Debug Flag
 
 Append `--debug` flag to enable debug mode.
 
-*Note:* Debug output from `vagrant-service-manager` is prepended with
+NOTE: Debug output from `vagrant-service-manager` is prepended with
 the following string:
-
 `DEBUG command: [ service-manager: <command name / log message> ]`
 
 === Exit codes
@@ -226,7 +196,8 @@ As most other open-source projects, vagrant-service-manager has a set of convent
 about how to write code for it. It follows the
 https://github.com/bbatsov/ruby-style-guide[Ruby Style Guide].
 
-You can verify that your changes adhere to this style using the http://batsov.com/rubocop[RuboCop] Rake task:
+You can verify that your changes adhere to this style using the
+ http://batsov.com/rubocop[RuboCop] Rake task:
 
 --------------------------
 $ bundle exec rake rubocop
@@ -258,7 +229,7 @@ acceptance tests. They can be run via:
 $ bundle exec rake features
 ---------------------------
 
-*Note:* This Cucumber tests do not run on Windows, pending resolution of
+NOTE: This Cucumber tests do not run on Windows, pending resolution of
 https://github.com/projectatomic/vagrant-service-manager/issues/213[Issue #213].
 
 Per default, only the scenarios for ADB in combination with the


### PR DESCRIPTION
Created a new document for all the available commands and examples for vagrant-service-manager plugin.
'Available commands' section from the current Readme will be condensed to a list of the 4 higher level commands with a link to this document saying - for further details refer to 'Commands.adoc'.
Thoughts please.
