### PR TITLE
Fix 309 Adding current provider to config.vm.box option in Vagrantfil…

### DIFF
--- a/features/box-command.feature
+++ b/features/box-command.feature
@@ -14,7 +14,7 @@ Feature: Command output from box command
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/features/env-command.feature
+++ b/features/env-command.feature
@@ -14,7 +14,7 @@ Feature: Command output from env command
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/features/help-command.feature
+++ b/features/help-command.feature
@@ -14,7 +14,7 @@ Feature: Command output from help command
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/features/install-cli.feature
+++ b/features/install-cli.feature
@@ -14,7 +14,7 @@ Feature: Command behavior of client side tools installation
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/features/openshift.feature
+++ b/features/openshift.feature
@@ -14,7 +14,7 @@ Feature: Command output from various OpenShift related commands
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/features/service-operation.feature
+++ b/features/service-operation.feature
@@ -14,7 +14,7 @@ Feature: Command output from service operations like stop/start/restart
     end
 
     Vagrant.configure('2') do |config|
-      config.vm.box = '<box>'
+      config.vm.box = '<box>-<provider>'
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true


### PR DESCRIPTION
Fix #309 

…e used by Cucumber to avoid adb and cdk image to be cached under the same name in the libvirt pool
