### PR TITLE
Fix #313 Explicitly requiring rubyzip as dependency in gemspec. Despi…

### DIFF
--- a/vagrant-service-manager.gemspec
+++ b/vagrant-service-manager.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
+
+  spec.add_dependency 'rubyzip', '~> 1.2.0'
 end


### PR DESCRIPTION
Fix #313  
…te being in the core Ruby packages, it seems this is still needed on Fedora
