### PR TITLE
Added installation prerequisites with link to ADB install doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ image::https://ci.centos.org/buildStatus/icon?job=vagrant-service-manager[link="
 
 == Prerequisites
 
-Follow the [ADB installation instructions](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst#installing-the-atomic-developer-bundle)
+Follow the https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst[ADB installation instructions]
 to install a virtualization provider, Vagrant, and any additional dependencies that your operating system requires.
 
 == Installation

--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,11 @@ toc::[]
 [[img-build-status]]
 image::https://ci.centos.org/buildStatus/icon?job=vagrant-service-manager[link="https://ci.centos.org/job/vagrant-service-manager"]
 
+== Prerequisites
+
+Follow the [ADB installation instructions](https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst#installing-the-atomic-developer-bundle)
+to install a virtualization provider, Vagrant, and any additional dependencies that your operating system requires.
+
 == Installation
 
 The vagrant-service-manager plugin is distributed as a Ruby Gem.


### PR DESCRIPTION
Related to issue 450 in the ADB repository: https://github.com/projectatomic/adb-atomic-developer-bundle/issues/450

This PR adds a prerequisites step to the installation, with a link to the main ADB install instructions (to avoid documenting the information in multiple places).
