### PR TITLE
Fix #350: Add support of 'install-cli' command for kubernetes

### DIFF
--- a/.github/ISSUE_TEMPLATE.MD
+++ b/.github/ISSUE_TEMPLATE.MD
@@ -37,3 +37,4 @@ VirtualBox and/or Libvirt and/or HyperV (for CDK only)
 
 
 **Describe the results you expected:**
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,6 +39,8 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 111
+  Exclude:
+    - 'lib/vagrant-service-manager/plugin_util.rb'
 
 # Offense count: 1
 Metrics/PerceivedComplexity:

--- a/features/cdk-openshift.feature
+++ b/features/cdk-openshift.feature
@@ -18,11 +18,7 @@ Feature: Command output from various OpenShift related commands in CDK
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true
-      config.servicemanager.services = 'docker'
-      config.vm.provision "shell", inline: <<-SHELL
-        systemctl enable openshift 2>&1
-        systemctl start openshift | true
-      SHELL
+      config.servicemanager.services = 'docker, openshift'
     end
     """
 
@@ -69,6 +65,10 @@ Feature: Command output from various OpenShift related commands in CDK
     # run following command to configure your shell:
     # eval "$(vagrant service-manager env)"
     """
+
+    When I run `bundle exec vagrant service-manager install-cli openshift`
+    Then the exit status should be 0
+    And the binary "oc" should be installed
 
     Examples:
       | box   | provider   | ip          |

--- a/features/env-command.feature
+++ b/features/env-command.feature
@@ -32,6 +32,7 @@ Feature: Command output from env command
     Objects:
           docker      display information and environment variables for docker
           openshift   display information and environment variables for openshift
+          kubernetes  display information and environment variables for kubernetes
 
     If OBJECT is omitted, display the information for all active services
 

--- a/features/kubernetes.feature
+++ b/features/kubernetes.feature
@@ -18,6 +18,7 @@ Feature: Command output from various Kubernetes related commands
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true
 
+      config.registration.skip = true
       config.servicemanager.services = 'kubernetes'
     end
     """
@@ -30,9 +31,15 @@ Feature: Command output from various Kubernetes related commands
     Then the exit status should be 0
     And the binary "kubectl" should be installed
 
+    When I successfully run `bundle exec vagrant service-manager env kubernetes`
+    Then stdout from "bundle exec vagrant service-manager env kubernetes" should be evaluable in a shell
+    And stdout from "bundle exec vagrant service-manager env kubernetes" should match /export KUBECONFIG=.*\/.vagrant.d\/data\/service-manager\/kubeconfig/
+    And stdout from "bundle exec vagrant service-manager env kubernetes" should match /# eval "\$\(vagrant service-manager env kubernetes\)"/
+
+    When I successfully run `bundle exec vagrant service-manager env kubernetes --script-readable`
+    Then stdout from "bundle exec vagrant service-manager env kubernetes --script-readable" should be script readable
+
     Examples:
       | box   | provider   | ip          |
       | adb   | virtualbox | 10.10.10.42 |
-      | adb   | libvirt    | 10.10.10.42 |
       | cdk   | virtualbox | 10.10.10.42 |
-      | cdk   | libvirt    | 10.10.10.42 |

--- a/features/kubernetes.feature
+++ b/features/kubernetes.feature
@@ -1,0 +1,38 @@
+Feature: Command output from various Kubernetes related commands
+  service-manager should return the correct output from commands affecting Kubernetes
+
+  Scenario Outline: Boot and execute commands
+    Given box is <box>
+    And provider is <provider>
+    And a file named "Vagrantfile" with:
+    """
+    begin
+      require 'vagrant-libvirt'
+    rescue LoadError
+      # NOOP
+    end
+
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
+      config.vm.network :private_network, ip: '<ip>'
+      config.vm.synced_folder '.', '/vagrant', disabled: true
+
+      config.servicemanager.services = 'kubernetes'
+    end
+    """
+
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    When I successfully run `bundle exec vagrant service-manager status kubernetes`
+    Then stdout from "bundle exec vagrant service-manager status kubernetes" should contain "kubernetes - running"
+
+    When I run `bundle exec vagrant service-manager install-cli kubernetes`
+    Then the exit status should be 0
+    And the binary "kubectl" should be installed
+
+    Examples:
+      | box   | provider   | ip          |
+      | adb   | virtualbox | 10.10.10.42 |
+      | adb   | libvirt    | 10.10.10.42 |
+      | cdk   | virtualbox | 10.10.10.42 |
+      | cdk   | libvirt    | 10.10.10.42 |

--- a/lib/vagrant-service-manager/binary_handlers/adb_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/adb_binary_handler.rb
@@ -4,52 +4,6 @@ module VagrantPlugins
       def initialize(machine, env, options)
         super(machine, env, options)
       end
-
-      def build_archive_path
-        @archive_file_path = "#{@temp_bin_dir}/#{File.basename(@url)}"
-      end
-
-      def ensure_binary_and_temp_directories
-        FileUtils.mkdir_p(bin_dir) unless File.directory?(bin_dir)
-        FileUtils.mkdir_p(@temp_bin_dir) unless File.directory?(@temp_bin_dir)
-      end
-
-      def download_archive
-        return @skip_download = true if File.exist?(@archive_file_path)
-        Vagrant::Util::Downloader.new(@url, @archive_file_path).download!
-      rescue Vagrant::Errors::DownloaderError => e
-        @ui.error e.message
-        exit 126
-      end
-
-      def prepare_binary
-        tmp_binary_file_path = @archive_file_path
-
-        # If binary is in archive format, extract it
-        if binary_archived?
-          tmp_binary_file_path = "#{archive_dir_name}/#{binary_name}"
-          archive_handler_class.new(@archive_file_path, tmp_binary_file_path, file_regex).unpack
-        end
-
-        FileUtils.cp(tmp_binary_file_path, @path)
-        File.chmod(0o755, @path)
-      rescue StandardError => e
-        @ui.error e.message
-        exit 126
-      end
-
-      def print_message
-        binary_path = PluginUtil.format_path(@path)
-        @ui.info I18n.t(LABEL,
-                        path: binary_path, dir: File.dirname(binary_path), service: @type,
-                        binary: binary_name, when: (@binary_exists ? 'already' : 'now'))
-      end
-
-      private
-
-      def binary_archived?
-        BINARY_ARCHIVE_FORMATS.include? File.extname(@archive_file_path)
-      end
     end
   end
 end

--- a/lib/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler.rb
@@ -1,0 +1,32 @@
+module VagrantPlugins
+  module ServiceManager
+    class ADBKubernetesBinaryHandler < ADBBinaryHandler
+      # http://richieescarez.github.io/kubernetes/v1.0/docs/getting-started-guides/aws/kubectl.html
+      BINARY_BASE_URL = 'https://storage.googleapis.com/kubernetes-release/release'.freeze
+
+      def initialize(machine, env, options)
+        super(machine, env, options)
+      end
+
+      def build_download_url
+        @url = "#{BINARY_BASE_URL}/v#{@version}/bin/#{os_type}/#{arch}/kubectl"
+      end
+
+      private
+
+      def os_type
+        if Vagrant::Util::Platform.windows?
+          'windows'
+        elsif Vagrant::Util::Platform.linux?
+          'linux'
+        elsif Vagrant::Util::Platform.darwin?
+          'darwin'
+        end
+      end
+
+      def arch
+        'amd64' # only supported arch
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
       end
 
       def build_download_url
-        @url = "#{BINARY_BASE_URL}/v#{@version}/bin/#{os_type}/#{arch}/kubectl"
+        @url = "#{BINARY_BASE_URL}/v#{@version}/bin/#{os_type}/#{arch}/kubectl#{ext}"
       end
 
       private
@@ -26,6 +26,10 @@ module VagrantPlugins
 
       def arch
         'amd64' # only supported arch
+      end
+
+      def ext
+        Vagrant::Util::Platform.windows? ? '.exe' : ''
       end
     end
   end

--- a/lib/vagrant-service-manager/binary_handlers/adb_openshift_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/adb_openshift_binary_handler.rb
@@ -22,7 +22,6 @@ module VagrantPlugins
         tokens = data.match("-v#{@version}-(.*)-#{archive_ext}").captures
         tokens.first unless tokens.empty?
       rescue StandardError
-        @ui.error e.message
         raise I18n.t('servicemanager.commands.install_cli.unsupported_version')
       end
 

--- a/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
@@ -9,11 +9,12 @@ module VagrantPlugins
     class BinaryHandler
       BINARY_ARCHIVE_FORMATS = ['.tgz', '.tar.gz', '.gz', '.zip'].freeze
       BINARY_NAME = {
-        docker: 'docker', openshift: 'oc'
+        docker: 'docker', openshift: 'oc', kubernetes: 'kubectl'
       }.freeze
       VERSION_CMD = {
         docker: "docker version --format '{{.Server.Version}}'",
-        openshift: "oc version | grep -oE 'oc v([0-9a-z.]+-?[a-z0-9]*.?[0-9])' | sed -E 's/oc v//'"
+        openshift: "oc version | grep -oE 'oc v([0-9a-z.]+-?[a-z0-9]*.?[0-9])' | sed -E 's/oc v//'",
+        kubernetes: %q(kubectl version --client | sed -E 's/(.*)v([0-9a-z.]+-?[a-z0-9]*.?[0-9]*)",(.*)/\2/')
       }.freeze
       BINARY_REGEX = {
         windows: { docker: %r{\/docker.exe$}, openshift: /oc.exe$/ },
@@ -29,7 +30,7 @@ module VagrantPlugins
 
       def initialize(machine, env, options)
         @machine = machine
-        @ui      = env.ui
+        @ui = env.ui
         @url = ''
         @binary_exists = true
         @skip_download = false

--- a/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
@@ -50,22 +50,44 @@ module VagrantPlugins
         prepare_binary
       end
 
-      def build_download_url
-      end
-
       def build_archive_path
+        @archive_file_path = "#{@temp_bin_dir}/#{File.basename(@url)}"
       end
 
       def ensure_binary_and_temp_directories
+        FileUtils.mkdir_p(bin_dir) unless File.directory?(bin_dir)
+        FileUtils.mkdir_p(@temp_bin_dir) unless File.directory?(@temp_bin_dir)
       end
 
       def download_archive
+        return @skip_download = true if File.exist?(@archive_file_path)
+        Vagrant::Util::Downloader.new(@url, @archive_file_path).download!
+      rescue Vagrant::Errors::DownloaderError => e
+        @ui.error e.message
+        exit 126
       end
 
       def prepare_binary
+        tmp_binary_file_path = @archive_file_path
+
+        # If binary is in archive format, extract it
+        if binary_archived?
+          tmp_binary_file_path = "#{archive_dir_name}/#{binary_name}"
+          archive_handler_class.new(@archive_file_path, tmp_binary_file_path, file_regex).unpack
+        end
+
+        FileUtils.cp(tmp_binary_file_path, @path)
+        File.chmod(0o755, @path)
+      rescue StandardError => e
+        @ui.error e.message
+        exit 126
       end
 
       def print_message
+        bin_path = PluginUtil.format_path(@path)
+        @ui.info I18n.t(LABEL,
+                        path: bin_path, dir: File.dirname(bin_path), service: @type,
+                        binary: binary_name, when: (@binary_exists ? 'already' : 'now'))
       end
 
       def archive_dir_name
@@ -108,6 +130,10 @@ module VagrantPlugins
       end
 
       private
+
+      def binary_archived?
+        BINARY_ARCHIVE_FORMATS.include? File.extname(@archive_file_path)
+      end
 
       def archive_handler_name
         ARCHIVE_MAP[File.extname(@url)] + 'Handler'

--- a/lib/vagrant-service-manager/binary_handlers/cdk_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/cdk_binary_handler.rb
@@ -4,30 +4,6 @@ module VagrantPlugins
       def initialize(machine, env, options = {})
         super(machine, env, options)
       end
-
-      # TODO
-      def build_download_url
-      end
-
-      # TODO
-      def build_archive_path
-      end
-
-      # TODO
-      def ensure_binary_and_temp_directories
-      end
-
-      # TODO
-      def download_archive
-      end
-
-      # TODO
-      def prepare_binary
-      end
-
-      # TODO
-      def print_message
-      end
     end
   end
 end

--- a/lib/vagrant-service-manager/binary_handlers/cdk_docker_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/cdk_docker_binary_handler.rb
@@ -1,6 +1,7 @@
 module VagrantPlugins
   module ServiceManager
-    class CDKDockerBinaryHandler < CDKBinaryHandler
+    # Currently client binary installation of docker for CDK is same as ADB
+    class CDKDockerBinaryHandler < ADBDockerBinaryHandler
       def initialize(machine, env, options)
         super(machine, env, options)
       end

--- a/lib/vagrant-service-manager/binary_handlers/cdk_kubernetes_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/cdk_kubernetes_binary_handler.rb
@@ -1,0 +1,10 @@
+module VagrantPlugins
+  module ServiceManager
+    # Currently client binary installation of kubernetes for CDK is same as ADB
+    class CDKKubernetesBinaryHandler < ADBKubernetesBinaryHandler
+      def initialize(machine, env, options)
+        super(machine, env, options)
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/binary_handlers/cdk_openshift_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/cdk_openshift_binary_handler.rb
@@ -1,7 +1,13 @@
 module VagrantPlugins
   module ServiceManager
-    class CDKOpenshiftBinaryHandler < CDKBinaryHandler
+    # Currently client binary installation of openshift for CDK is same as ADB
+    class CDKOpenshiftBinaryHandler < ADBOpenshiftBinaryHandler
+      # Default to latest stable origin oc version for CDK as it is different than
+      # OSE oc version running inside CDK development environment
+      LATEST_OC_VERSION = '1.2.1'.freeze
+
       def initialize(machine, env, options)
+        options['--cli-version'] = LATEST_OC_VERSION unless options['--cli-version']
         super(machine, env, options)
       end
     end

--- a/lib/vagrant-service-manager/command.rb
+++ b/lib/vagrant-service-manager/command.rb
@@ -8,9 +8,11 @@ require_relative 'binary_handlers/binary_handler'
 require_relative 'binary_handlers/adb_binary_handler'
 require_relative 'binary_handlers/cdk_binary_handler'
 require_relative 'binary_handlers/adb_docker_binary_handler'
-require_relative 'binary_handlers/adb_openshift_binary_handler'
 require_relative 'binary_handlers/cdk_docker_binary_handler'
+require_relative 'binary_handlers/adb_openshift_binary_handler'
 require_relative 'binary_handlers/cdk_openshift_binary_handler'
+require_relative 'binary_handlers/adb_kubernetes_binary_handler'
+require_relative 'binary_handlers/cdk_kubernetes_binary_handler'
 
 module VagrantPlugins
   module ServiceManager

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -2,7 +2,7 @@ require 'set'
 
 module VagrantPlugins
   module ServiceManager
-    SERVICES = %w(docker openshift).freeze
+    SERVICES = %w(docker openshift kubernetes).freeze
     CONFIG_KEYS = [
       :services, :openshift_docker_registry,
       :openshift_image_name, :openshift_image_tag

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -44,11 +44,19 @@ module VagrantPlugins
                            services: SERVICES.inspect)
         end
 
+        if SERVICES.drop(1).to_set.subset? configured_services.to_set
+          errors << I18n.t('servicemanager.config.only_one_service')
+        end
+
         errors
       end
 
       def supported_services?
-        @services.split(',').map(&:strip).to_set.subset?(SERVICES.to_set)
+        configured_services.to_set.subset? SERVICES.to_set
+      end
+
+      def configured_services
+        @services.split(',').map(&:strip)
       end
     end
   end

--- a/lib/vagrant-service-manager/installer.rb
+++ b/lib/vagrant-service-manager/installer.rb
@@ -28,11 +28,6 @@ module VagrantPlugins
       private
 
       def validate_prerequisites
-        if @type == :kubernetes
-          @env.ui.info I18n.t('servicemanager.commands.install_cli.kube_not_supported')
-          exit 126
-        end
-
         unless PluginUtil.service_running?(@machine, @type.to_s)
           @env.ui.info I18n.t('servicemanager.commands.install_cli.service_not_enabled',
                               service: @type)

--- a/lib/vagrant-service-manager/installer.rb
+++ b/lib/vagrant-service-manager/installer.rb
@@ -28,11 +28,6 @@ module VagrantPlugins
       private
 
       def validate_prerequisites
-        if @box_version == 'cdk'
-          @env.ui.info I18n.t('servicemanager.commands.install_cli.unsupported_box')
-          exit 126
-        end
-
         if @type == :kubernetes
           @env.ui.info I18n.t('servicemanager.commands.install_cli.kube_not_supported')
           exit 126

--- a/lib/vagrant-service-manager/service_base.rb
+++ b/lib/vagrant-service-manager/service_base.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
         @machine = machine
         @env = env
         @ui = env.respond_to?('ui') ? env.ui : env[:ui]
+        home_path = env.respond_to?('home_path') ? env.home_path : env[:home_path]
+        @plugin_dir = File.join(home_path, 'data', 'service-manager')
         @services = @machine.config.servicemanager.services.split(',').map(&:strip)
       end
 

--- a/lib/vagrant-service-manager/service_base.rb
+++ b/lib/vagrant-service-manager/service_base.rb
@@ -1,10 +1,19 @@
 module VagrantPlugins
   module ServiceManager
     class ServiceBase
-      def initialize(machine, _env)
+      def initialize(machine, env)
         @machine = machine
-        @env = machine.env
-        @ui = @env.ui
+        @env = env
+        @ui = env.respond_to?('ui') ? env.ui : env[:ui]
+        @services = @machine.config.servicemanager.services.split(',').map(&:strip)
+      end
+
+      def service_start_allowed?
+        true # always start service by default
+      end
+
+      def cdk?
+        @machine.guest.capability(:os_variant) == 'cdk'
       end
     end
   end

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -11,13 +11,15 @@ module VagrantPlugins
       end
 
       def execute
-        command = 'sudo rm /etc/docker/ca.pem && sudo systemctl restart docker'
+        if service_start_allowed?
+          command = 'sudo rm /etc/docker/ca.pem && sudo systemctl restart docker'
 
-        exit_code = PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
-        # Copy certs on command execution success
-        if exit_code
-          secrets_path = PluginUtil.host_docker_path(@machine)
-          PluginUtil.copy_certs_to_host(@machine, secrets_path, @ui)
+          exit_code = PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+          # Copy certs on command execution success
+          if exit_code
+            secrets_path = PluginUtil.host_docker_path(@machine)
+            PluginUtil.copy_certs_to_host(@machine, secrets_path, @ui)
+          end
         end
       end
 

--- a/lib/vagrant-service-manager/services/docker.rb
+++ b/lib/vagrant-service-manager/services/docker.rb
@@ -15,8 +15,9 @@ module VagrantPlugins
           command = 'sudo rm /etc/docker/ca.pem && sudo systemctl restart docker'
 
           exit_code = PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+
           # Copy certs on command execution success
-          if exit_code
+          if exit_code.zero?
             secrets_path = PluginUtil.host_docker_path(@machine)
             PluginUtil.copy_certs_to_host(@machine, secrets_path, @ui)
           end
@@ -46,7 +47,7 @@ module VagrantPlugins
 
           options[:api_version] = PluginUtil.execute_once(@machine, @ui, api_version_cmd)
           # Display the information, irrespective of the copy operation
-          print_env_info(@ui, options)
+          print_env_info(options)
         else
           @ui.error I18n.t('servicemanager.commands.env.service_not_running',
                            name: @service_name)
@@ -56,7 +57,7 @@ module VagrantPlugins
 
       private
 
-      def print_env_info(ui, options)
+      def print_env_info(options)
         PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
 
         label = PluginUtil.env_label(options[:script_readable])
@@ -69,9 +70,9 @@ module VagrantPlugins
                          api_version: options[:api_version])
         # Puts is used to escape and render the back slashes in Windows path
         message = puts(message) if Vagrant::Util::Platform.windows?
-        ui.info(message)
+        @ui.info(message)
         return if options[:script_readable] || options[:all]
-        PluginUtil.print_shell_configure_info(ui, ' docker')
+        PluginUtil.print_shell_configure_info(@ui, ' docker')
       end
     end
   end

--- a/lib/vagrant-service-manager/services/kubernetes.rb
+++ b/lib/vagrant-service-manager/services/kubernetes.rb
@@ -4,12 +4,14 @@ module VagrantPlugins
       def initialize(machine, env)
         super(machine, env)
         @service_name = 'kubernetes'
+        @kubeconfig_path = "#{@plugin_dir}/kubeconfig"
       end
 
       def execute
         if service_start_allowed?
           command = 'sccli kubernetes'
-          PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+          exit_code = PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+          PluginUtil.generate_kubeconfig(@machine, @ui, @plugin_dir) if exit_code.zero?
         end
       end
 
@@ -18,11 +20,32 @@ module VagrantPlugins
       end
 
       def info(options = {})
-        # TODO: Implement info method
+        if PluginUtil.service_running?(@machine, @service_name)
+          options[:kubeconfig_path] = @kubeconfig_path
+          print_env_info(options)
+        else
+          @ui.error I18n.t('servicemanager.commands.env.service_not_running',
+                           name: @service_name)
+          exit 126
+        end
       end
 
       def service_start_allowed?
         @services.include?('kubernetes')
+      end
+
+      private
+
+      def print_env_info(options)
+        PluginLogger.debug("script_readable: #{options[:script_readable] || false}")
+
+        label = PluginUtil.env_label(options[:script_readable])
+        message = I18n.t("servicemanager.commands.env.kubernetes.#{label}",
+                         kubeconfig_path: options[:kubeconfig_path])
+        @ui.info(message)
+
+        return if options[:script_readable] || options[:all]
+        PluginUtil.print_shell_configure_info(@ui, ' kubernetes')
       end
     end
   end

--- a/lib/vagrant-service-manager/services/kubernetes.rb
+++ b/lib/vagrant-service-manager/services/kubernetes.rb
@@ -7,7 +7,10 @@ module VagrantPlugins
       end
 
       def execute
-        # TODO: Implement execute method
+        if service_start_allowed?
+          command = 'sccli kubernetes'
+          PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+        end
       end
 
       def status
@@ -16,6 +19,10 @@ module VagrantPlugins
 
       def info(options = {})
         # TODO: Implement info method
+      end
+
+      def service_start_allowed?
+        @services.include?('kubernetes')
       end
     end
   end

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -10,8 +10,13 @@ module VagrantPlugins
       end
 
       def execute
-        command = "#{@extra_cmd} sccli openshift"
-        PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+        if service_start_allowed?
+          # openshift to be started by default for CDK
+          command = "#{@extra_cmd} sccli openshift"
+          PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
+        end
+      rescue Vagrant::Errors::GuestCapabilityNotFound
+        PluginLogger.debug('Guest capability not found while starting OpenShift service')
       end
 
       def status
@@ -31,6 +36,10 @@ module VagrantPlugins
                            name: 'OpenShift')
           exit 126
         end
+      end
+
+      def service_start_allowed?
+        (cdk? && @services.empty?) || @services.include?('openshift')
       end
 
       private

--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -11,7 +11,6 @@ module VagrantPlugins
 
       def execute
         if service_start_allowed?
-          # openshift to be started by default for CDK
           command = "#{@extra_cmd} sccli openshift"
           PluginUtil.execute_and_exit_on_fail(@machine, @ui, command)
         end
@@ -39,6 +38,7 @@ module VagrantPlugins
       end
 
       def service_start_allowed?
+        # openshift to be started by default for CDK
         (cdk? && @services.empty?) || @services.include?('openshift')
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -181,9 +181,6 @@ en:
 
           # run following command to configure your shell:
           # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager install-cli %{service} | tr -d '\r')"
-        unsupported_box: |-
-          The CDK does not support client binary installs via the 'install-cli' command.
-          Please visit access.redhat.com to download client binaries.
         service_not_enabled: |-
           '%{service}' service is not enabled.
         kube_not_supported: |-
@@ -191,7 +188,8 @@ en:
         unsupported_version: |-
           Something went wrong to find the correct download link.
           We recommend you to use '--cli-version' for your desired client version.
-          If still facing issues, please report to https://github.com/projectatomic/vagrant-service-manager.
+          If you are still facing issues, please report to
+          https://github.com/projectatomic/vagrant-service-manager.
 
       status:
         nil: |-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -183,8 +183,6 @@ en:
           # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager install-cli %{service} | tr -d '\r')"
         service_not_enabled: |-
           '%{service}' service is not enabled.
-        kube_not_supported: |-
-          Installation of Kubernetes client library via the install-cli command is not supported yet.
         unsupported_version: |-
           Something went wrong to find the correct download link.
           We recommend you to use '--cli-version' for your desired client version.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,10 +1,12 @@
 en:
+# Vagrant related translations
   vagrant:
     errors:
       url_validation_error: |-
         Download URL is not accessible.
         Possible reason: Invalid version name
 
+# Plugin related translations
   servicemanager:
     synopsis: |-
       provides the IP address:port and tls certificate file location for a docker daemon
@@ -13,15 +15,14 @@ en:
       Try this in the directory with your Vagrantfile:
       vagrant up
 
-#-------------------------------------------------------------------------------
-# Translations for config validation errors
-#-------------------------------------------------------------------------------
+# Config related translations
     config:
       supported_devices: |-
         services should be subset of %{services}.
-#-------------------------------------------------------------------------------
-# Translations for commands. e.g. `vagrant x`
-#-------------------------------------------------------------------------------
+      only_one_service: |-
+        Only one of the service out of openshift and kubernetes can be enabled at a time.
+
+# Command related translations
     commands:
       help:
         default: |-
@@ -46,6 +47,7 @@ en:
           Objects:
                 docker      display information and environment variables for docker
                 openshift   display information and environment variables for openshift
+                kubernetes  display information and environment variables for kubernetes
 
           If OBJECT is omitted, display the information for all active services
 
@@ -106,7 +108,6 @@ en:
 
           Example:
                 vagrant service-manager install-cli docker
-
       env:
         docker:
           windows: |-
@@ -158,9 +159,24 @@ en:
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
             DOCKER_REGISTRY=%{docker_registry}
+        kubernetes:
+          windows: |-
+            # Set the following environment variables to enable access to the
+            # kubernetes server running inside of the vagrant virtual machine:
+            setx KUBECONFIG %{kubeconfig_path}
+          non_windows: |-
+            # Set the following environment variables to enable access to the
+            # kubernetes server running inside of the vagrant virtual machine:
+            export KUBECONFIG=%{kubeconfig_path}
+          windows_cygwin: |-
+            # Set the following environment variables to enable access to the
+            # kubernetes server running inside of the vagrant virtual machine:
+            export KUBECONFIG=%{kubeconfig_path}
+          script_readable: |-
+            KUBECONFIG=%{kubeconfig_path}
         windows_cygwin_configure_info: |-
-            # run following command to configure your shell:
-            # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env%{command} | tr -d '\r')"
+          # run following command to configure your shell:
+          # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env%{command} | tr -d '\r')"
         unix_configure_info: |-
           # run following command to configure your shell:
           # eval "$(vagrant service-manager env%{command})"
@@ -171,7 +187,6 @@ en:
         sccli_only_support: |-
           Only sccli services are supported. For example:
             docker, openshift and kubernetes
-
       install_cli:
         message: |-
           # Binary %{when} available at %{path}
@@ -188,7 +203,6 @@ en:
           We recommend you to use '--cli-version' for your desired client version.
           If you are still facing issues, please report to
           https://github.com/projectatomic/vagrant-service-manager.
-
       status:
         nil: |-
           Configured services:
@@ -198,3 +212,24 @@ en:
         unsupported_service: |-
           Unknown service '%{service}'.
           Supported services are %{services}.
+
+# Kube config template translation
+    kube_config: |-
+      apiVersion: v1
+      clusters:
+      - cluster:
+          insecure-skip-tls-verify: true
+          server: https://%{ip}:6443
+        name: k8s
+      contexts:
+      - context:
+          cluster: k8s
+          user: "serviceaccount"
+        name: k8s
+      current-context: k8s
+      kind: Config
+      preferences: {}
+      users:
+      - name: serviceaccount
+        user:
+          token: %{token}

--- a/test/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler_test.rb
+++ b/test/vagrant-service-manager/binary_handlers/adb_kubernetes_binary_handler_test.rb
@@ -1,0 +1,103 @@
+require_relative '../../test_helper'
+require 'vagrant/util/downloader'
+
+# Tests through ADBKubernetesBinaryHandler to BinaryHandler
+module VagrantPlugins
+  module ServiceManager
+    describe ADBKubernetesBinaryHandler do
+      before do
+        @machine = fake_machine
+        @options = { type: :kubernetes, '--cli-version' => '1.2.0' } # 1.2.0 is available in CDK/ADB VM
+        @base_download_url = 'https://storage.googleapis.com/kubernetes-release/release'
+        # set test path
+        @plugin_test_path = "#{@machine.env.data_dir}/service-manager/test"
+        ServiceManager.temp_dir = "#{@plugin_test_path}/temp"
+        ServiceManager.bin_dir = "#{@plugin_test_path}/bin"
+
+        @handler = ADBKubernetesBinaryHandler.new(@machine, @machine.env, @options)
+      end
+
+      after do
+        FileUtils.rmtree(@plugin_test_path) if File.directory? @plugin_test_path
+      end
+
+      it 'should set defaults values properly' do
+        @handler.instance_variable_get('@machine').must_equal @machine
+        @handler.url.must_equal ''
+        @handler.binary_exists.must_equal true
+        @handler.skip_download.must_equal false
+        @handler.archive_file_path.must_equal ''
+        @handler.type.must_equal @options[:type]
+        @handler.version.must_equal @options['--cli-version']
+        @handler.path.must_equal "#{ServiceManager.bin_dir}/kubernetes/1.2.0/kubectl"
+        expected_temp_bin_dir = "#{ServiceManager.temp_dir}/kubernetes"
+        @handler.instance_variable_get('@temp_bin_dir').must_equal expected_temp_bin_dir
+      end
+
+      it 'should build download url' do
+        expected_url = @base_download_url + '/v1.2.0/bin/linux/amd64/kubectl'
+        expected_url.sub!(/Linux/, 'Darwin') if Vagrant::Util::Platform.darwin?
+
+        @handler.send(:build_download_url)
+        @handler.instance_variable_get('@url').must_equal expected_url
+      end
+
+      it 'should validate download url' do
+        @handler.build_download_url
+        @handler.validate_url.must_equal true
+      end
+
+      it 'should raise error with invalid --cli-version' do
+        @options['--cli-version'] = '111.222.333'
+        @handler = ADBKubernetesBinaryHandler.new(@machine, @machine.env, @options)
+        @handler.build_download_url
+        assert_raises(URLValidationError) { @handler.validate_url }
+      end
+
+      it 'should build archive path' do
+        expected_path = "#{ServiceManager.temp_dir}/kubernetes/kubectl"
+        @handler.build_download_url
+        @handler.build_archive_path
+        @handler.instance_variable_get('@archive_file_path').must_equal expected_path
+      end
+
+      it 'should ensure availability of binary and temp directories' do
+        expected_bin_dir = "#{ServiceManager.bin_dir}/kubernetes"
+        expected_temp_dir = "#{ServiceManager.temp_dir}/kubernetes"
+
+        @handler.build_download_url
+        @handler.build_archive_path
+        @handler.ensure_binary_and_temp_directories
+
+        assert_equal(File.directory?(expected_bin_dir), true)
+        assert_equal(File.directory?(expected_temp_dir), true)
+      end
+
+      it 'should not download if archive file exists' do
+        archive_file_dir = "#{ServiceManager.temp_dir}/kubernetes"
+        FileUtils.mkdir_p(archive_file_dir) unless File.directory?(archive_file_dir)
+        FileUtils.touch("#{archive_file_dir}/kubectl")
+
+        @handler.build_download_url
+        @handler.build_archive_path
+        @handler.download_archive
+
+        @handler.skip_download.must_equal true
+      end
+
+      it 'should prepare binary properly' do
+        test_archive_path = "#{test_data_dir_path}/kubectl"
+
+        @handler.build_download_url
+        @handler.build_archive_path
+        @handler.ensure_binary_and_temp_directories
+
+        FileUtils.cp(test_archive_path, @handler.archive_file_path)
+
+        @handler.prepare_binary
+        @handler.binary_name.must_equal 'kubectl'
+        assert_equal(File.exist?(@handler.path), true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix #350 

Also includes:
-  kubernetes install-cli support for CDK
-  Vagrantfile configuration support for kubernetes, i.e `config.servicemanager.services = 'kubernetes`
- Unit tests for install-cli for kubernetes
- Acceptance tests for install-cli for kubernetes

For quick test at local one can use `bundle exec rake test rubocop features`.

My logs:

```
➜  vagrant-service-manager git:(fix-350) ✗ bundle exec rake test rubocop features
Run options: --seed 11468

# Running:

.....................................

Finished in 14.060475s, 2.6315 runs/s, 5.6897 assertions/s.

37 runs, 80 assertions, 0 failures, 0 errors, 0 skips
Running RuboCop...
Inspecting 46 files
..............................................

46 files inspected, no offenses detected
\Using existing ADB box (version 2.2.2) in /home/budhram/redhat/vagrant-service-manager/.boxes
|/home/budhram/.rvm/rubies/ruby-2.1.2/bin/ruby -S bundle exec cucumber
Using the default and html profiles...
---------------...............---------------.-------------------------------------------------------------------------------.........................-------------------------.-----------------------------------...........-----------.----------................--------------..........-------------------------------------------------------------...................................-----------------------------------.----------------------------------

24 scenarios (18 skipped, 6 passed)
450 steps (334 skipped, 116 passed)
13m8.380s
```
