### PR TITLE
Fix #379: Success message after vagrant up for Kubernetes

### DIFF
--- a/features/adb-openshift.feature
+++ b/features/adb-openshift.feature
@@ -18,17 +18,13 @@ Feature: Command output from various OpenShift related commands in ADB
       config.vm.box_url = 'file://../../.boxes/<box>-<provider>.box'
       config.vm.network :private_network, ip: '<ip>'
       config.vm.synced_folder '.', '/vagrant', disabled: true
-      config.servicemanager.services = 'docker, openshift'
 
-      config.servicemanager.openshift_image_tag = 'v1.2.1'
-      config.servicemanager.openshift_image_name = 'openshift/origin'
-      config.servicemanager.openshift_docker_registry = 'docker.io'
+      config.servicemanager.services = 'docker, openshift'
     end
     """
 
     When I successfully run `bundle exec vagrant up --provider <provider>`
-    # TODO, for some reason I can not use 'successfully' here. Seems the exit code is not 0 in this case!?
-    And I run `bundle exec vagrant service-manager env openshift`
+    And I successfully run `bundle exec vagrant service-manager env openshift`
     Then stdout from "bundle exec vagrant service-manager env openshift" should be evaluable in a shell
     And stdout from "bundle exec vagrant service-manager env openshift" should contain:
     """
@@ -51,31 +47,10 @@ Feature: Command output from various OpenShift related commands in ADB
     DOCKER_REGISTRY=hub.openshift.centos7-adb.<ip>.xip.io
     """
 
-    When I successfully run `bundle exec vagrant service-manager env`
-    Then stdout from "bundle exec vagrant service-manager env" should contain "export DOCKER_HOST=tcp://<ip>:2376"
-    And stdout from "bundle exec vagrant service-manager env" should match /export DOCKER_CERT_PATH=.*\/.vagrant\/machines\/cdk\/virtualbox\/docker/
-    And stdout from "bundle exec vagrant service-manager env" should contain "export DOCKER_TLS_VERIFY=1"
-    And stdout from "bundle exec vagrant service-manager env" should match /export DOCKER_API_VERSION=1.2\d/
-    And stdout from "bundle exec vagrant service-manager env" should match /# eval "\$\(vagrant service-manager env\)"/
-    And stdout from "bundle exec vagrant service-manager env" should contain:
-    """
-    # openshift env:
-    # You can access the OpenShift console on: https://<ip>:8443/console
-    # To use OpenShift CLI, run: oc login https://<ip>:8443
-    export OPENSHIFT_URL=https://<ip>:8443
-    export OPENSHIFT_WEB_CONSOLE=https://<ip>:8443/console
-    export DOCKER_REGISTRY=hub.openshift.centos7-adb.<ip>.xip.io
-
-    # run following command to configure your shell:
-    # eval "$(vagrant service-manager env)"
-    """
-
-    When I successfully run `bundle exec vagrant up --provider <provider>`
-    And I run `bundle exec vagrant service-manager install-cli openshift`
+    When I run `bundle exec vagrant service-manager install-cli openshift`
     Then the exit status should be 0
     And the binary "oc" should be installed
 
     Examples:
       | box   | provider   | ip          |
       | adb   | virtualbox | 10.10.10.42 |
-      | adb   | libvirt    | 10.10.10.42 |

--- a/lib/vagrant-service-manager/action/log_configured_service.rb
+++ b/lib/vagrant-service-manager/action/log_configured_service.rb
@@ -1,0 +1,26 @@
+module VagrantPlugins
+  module ServiceManager
+    module Action
+      class LogConfiguredServices
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @ui = env[:ui]
+          @services = @machine.config.servicemanager.services.split(',').map(&:strip)
+        end
+
+        def call(env)
+          @app.call(env)
+
+          @services.each do |service|
+            if !PluginUtil.service_running?(@machine, service)
+              @ui.info I18n.t('servicemanager.actions.service_failure', service: service.capitalize)
+            elsif PluginUtil.service_running?(@machine, service)
+              @ui.info I18n.t('servicemanager.actions.service_success', service: service.capitalize)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-service-manager/action/setup_network.rb
+++ b/lib/vagrant-service-manager/action/setup_network.rb
@@ -24,10 +24,7 @@ module VagrantPlugins
         end
 
         def add_private_network
-          @ui.info <<-MSG
-When using virtualbox, a non-NAT network interface is required.
-Adding a private network using DHCP
-          MSG
+          @ui.info I18n.t('servicemanager.action.private_network')
           @machine.config.vm.network :private_network, type: :dhcp
         end
       end

--- a/lib/vagrant-service-manager/plugin.rb
+++ b/lib/vagrant-service-manager/plugin.rb
@@ -21,11 +21,18 @@ module VagrantPlugins
       action_hook(:servicemanager, :machine_action_up) do |hook|
         hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network, setup_network)
         hook.after(Vagrant::Action::Builtin::SyncedFolders, Service)
+        hook.after Vagrant::Action::Builtin::Provision, final_actions
       end
 
       def self.setup_network
         Vagrant::Action::Builder.new.tap do |b|
           b.use Action::SetupNetwork
+        end
+      end
+
+      def self.final_actions
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Action::LogConfiguredServices
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -213,6 +213,14 @@ en:
           Unknown service '%{service}'.
           Supported services are %{services}.
 
+# Action related translations
+    actions:
+      service_success: '%{service} service configured successfully...'
+      service_failure: '%{service} service failed to configure properly...'
+      private_network: |-
+        When using Virtualbox, a non-NAT network interface is required.
+        Adding a private network using DHCP
+
 # Kube config template translation
     kube_config: |-
       apiVersion: v1


### PR DESCRIPTION
Fix #379 

Report success or failure message at the end of `vagrant up` process for services mentioned in Vagrantfile as
`config.servicemanager.services = 'kubernetes'`
