### PR TITLE
Fix #406 Service hooks doesn't start in vagrant reload

### DIFF
--- a/features/adb-openshift.feature
+++ b/features/adb-openshift.feature
@@ -51,6 +51,11 @@ Feature: Command output from various OpenShift related commands in ADB
     Then the exit status should be 0
     And the binary "oc" should be installed
 
+    When I successfully run `bundle exec vagrant reload`
+    And I successfully run `bundle exec vagrant service-manager status openshift`
+    Then the exit status should be 0
+    And the service "openshift" should be running
+
     Examples:
       | box   | provider   | ip          |
       | adb   | virtualbox | 10.10.10.42 |

--- a/lib/vagrant-service-manager/plugin.rb
+++ b/lib/vagrant-service-manager/plugin.rb
@@ -18,11 +18,14 @@ module VagrantPlugins
         Config
       end
 
-      action_hook(:servicemanager, :machine_action_up) do |hook|
-        hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network, setup_network)
-        hook.after(Vagrant::Action::Builtin::SyncedFolders, Service)
+      service_manager_hooks = lambda do |hook|
+        hook.before VagrantPlugins::ProviderVirtualBox::Action::Network, setup_network
+        hook.after Vagrant::Action::Builtin::SyncedFolders, Service
         hook.after Vagrant::Action::Builtin::Provision, final_actions
       end
+
+      action_hook :servicemanager, :machine_action_up, &service_manager_hooks
+      action_hook :servicemanager, :machine_action_reload, &service_manager_hooks
 
       def self.setup_network
         Vagrant::Action::Builder.new.tap do |b|


### PR DESCRIPTION
Fix #406 

Now, the services starts on vagrant reload too. My logs:

```
$ vagrant up --provider virtualbox
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'cdkv2'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: vagrant-service-manager_default_1476273881549_14627
.........
==> default: Configuring and enabling network interfaces...
==> default: Copying TLS certificates to /home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
==> default: Docker service configured successfully...
==> default: OpenShift service configured successfully...
==> default: Mounting SSHFS shared folder...
==> default: Mounting folder via SSHFS: /home/budhram => /home/budhram
==> default: Checking Mount..
==> default: Folder Successfully Mounted!
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: 
==> default: Successfully started and provisioned VM with 2 cores and 3072 MB of memory.
........ 
==> default: Configured users are (<username>/<password>):
==> default: openshift-dev/devel
==> default: admin/admin
==> default: 
==> default: If you have the oc client library on your host, you can also login from your host.

##### Reloading ######

$ vagrant reload
==> default: Attempting graceful shutdown of VM...
==> default: Clearing any previously set forwarded ports...
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
....
==> default: Configuring and enabling network interfaces...
==> default: Copying TLS certificates to /home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
==> default: Mounting SSHFS shared folder...
==> default: Mounting folder via SSHFS: /home/budhram => /home/budhram
==> default: Checking Mount..
==> default: Checking Mount..
==> default: Folder Successfully Mounted!
==> default: Docker service configured successfully...
==> default: Openshift service failed to configure properly...
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
==> default: Running provisioner: shell...
    default: Running: inline script
.... 
==> default: You can now access the OpenShift console on: https://10.1.2.2:8443/console
==> default: 
==> default: To use OpenShift CLI, run:
==> default: $ vagrant ssh
==> default: $ oc login
....
==> default: 
==> default: If you have the oc client library on your host, you can also login from your host.

$ vagrant service-manage status docker
docker - running

$ vagrant service-manage status openshift
openshift - running
```

There is already #409 issue which is why we are getting "openshift configuration error" on vagrant reload. Ignore it.
