### PR TITLE
Fix #376 --path option of install cli not working as expected

### DIFF
--- a/features/install-cli.feature
+++ b/features/install-cli.feature
@@ -53,14 +53,25 @@ Feature: Command behavior of client side tools installation
     When I run `bundle exec vagrant service-manager install-cli docker`
     Then the exit status should be 0
     And the binary "docker" should be installed
+    And the stderr should not contain anything
 
     When I run `bundle exec vagrant service-manager install-cli docker --cli-version 1.12.1`
     Then the exit status should be 0
     And the binary "docker" of service "docker" should be installed with version "1.12.1"
+    And the stderr should not contain anything
 
     When I evaluate and run `bundle exec vagrant service-manager install-cli docker --path #{ENV['VAGRANT_HOME']}/docker`
     Then the exit status should be 0
     And the binary should be installed in path "#{ENV['VAGRANT_HOME']}/docker"
+    And the stderr should not contain anything
+
+    When I evaluate and run `bundle exec vagrant service-manager install-cli docker --path #{ENV['VAGRANT_HOME']}/unknown_dir/docker`
+    Then the exit status should be 126
+    And stderr from evaluating and running "bundle exec vagrant service-manager install-cli docker --path #{ENV['VAGRANT_HOME']}/unknown_dir/docker" should match /Directory path #{ENV['VAGRANT_HOME']}/unknown_dir is invalid or doesn't exist/
+
+    When I run `bundle exec vagrant service-manager install-cli docker --path /foo/bar/docker`
+    Then the exit status should be 126
+    And stderr from evaluating and running "bundle exec vagrant service-manager install-cli docker --path /foo/bar/docker" should match /Permission denied @ dir_s_mkdir - /foo/
 
     Examples:
       | box   | provider   | ip          |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -85,12 +85,23 @@ Then(/^stdout from "([^"]*)" should be evaluable in a shell$/) do |cmd|
   output_is_evaluable(aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout))
 end
 
+Then(/^stdout after evaluating and running "([^"]*)" should be evaluable in a shell$/) do |cmd|
+  cmd = sanitize_text(eval('"' + cmd + '"'))
+  output_is_evaluable(aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout))
+end
+
 Then(/^stdout from "([^"]*)" should be script readable$/) do |cmd|
   output_is_script_readable(aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout))
 end
 
 Then(%r{^stdout from "([^"]*)" should match /(.*)/$}) do |cmd, regexp|
   aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stdout) =~ /#{regexp}/
+end
+
+Then(%r{^stderr from evaluating and running "([^"]*)" should match /(.*)/$}) do |cmd, regexp|
+  cmd = sanitize_text(eval('"' + cmd + '"'))
+  regexp = sanitize_text(eval('"' + regexp + '"'))
+  aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd)).send(:stderr) =~ /#{regexp}/
 end
 
 # track service process ID
@@ -171,4 +182,8 @@ When(/^I evaluate and run `([^`]*)`$/) do |cmd|
   cmd = eval('"' + cmd + '"')
   cmd = sanitize_text(cmd)
   run_simple(cmd, fail_on_error: false)
+end
+
+When(/^I sleep for (\d+) seconds$/) do |time|
+  sleep(time.to_i)
 end

--- a/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/binary_handler.rb
@@ -86,10 +86,10 @@ module VagrantPlugins
         exit 126
       end
 
-      def print_message
+      def print_message(options_msg)
         bin_path = PluginUtil.format_path(@path)
         @ui.info I18n.t(LABEL,
-                        path: bin_path, dir: File.dirname(bin_path), service: @type,
+                        path: bin_path, dir: File.dirname(bin_path), service: @type, options: options_msg,
                         binary: binary_name, when: (@binary_exists ? 'already' : 'now'))
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -198,7 +198,7 @@ en:
           export PATH=%{dir}:$PATH
 
           # run following command to configure your shell:
-          # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager install-cli %{service} | tr -d '\r')"
+          # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager install-cli %{service}%{options} | tr -d '\r')"
         service_not_enabled: |-
           '%{service}' service is not enabled.
         invalid_binary_path: |-


### PR DESCRIPTION
Fix #376
- install-cli command will fail if invalid --path is given or
  path needs permission
