### PR TITLE
Fix #335 'bundle exec vagrant up --provider libvirt' should work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ group :development do
   gem 'vagrant',
       git: 'https://github.com/mitchellh/vagrant.git',
       ref: 'v1.8.4'
-  gem 'vagrant-libvirt'              if RUBY_PLATFORM =~ /linux/i
-  gem 'fog-libvirt', '0.0.3'         if RUBY_PLATFORM =~ /linux/i # https://github.com/pradels/vagrant-libvirt/issues/568
   gem 'mechanize'
   gem 'json'
   gem 'cucumber', '~> 2.1'
@@ -23,4 +21,6 @@ end
 
 group :plugins do
   gemspec
+  gem 'vagrant-libvirt'              if RUBY_PLATFORM =~ /linux/i
+  gem 'fog-libvirt', '0.0.3'         if RUBY_PLATFORM =~ /linux/i # https://github.com/pradels/vagrant-libvirt/issues/568
 end


### PR DESCRIPTION
Fix #335 

We can now able to do `bundle exec vagrant up --provider libvirt`
