### PR TITLE
Fix #434 Align proxy config names similar to 'sccli'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,18 +153,20 @@ have IPv4 addresses, the address on eth2 is used.
 === HTTP Proxy Settings
 
 In an environment where the HTTP traffic needs to pass through an
-HTTP proxy server, set the `http_proxy`, `http_proxy_user` and
-`http_proxy_password` proxy configurations in the Vagrantfiles to enable
+HTTP proxy server, set the `proxy`, `proxy_user` and
+`proxy_password` proxy configurations in the Vagrantfiles to enable
 services like Docker and OpenShift to function correctly. +
 You can do so via:
  +
 -----
-config.servicemanager.http_proxy = <Proxy URL>
-config.servicemanager.http_proxy_user = <Proxy user name>
-config.servicemanager.http_proxy_password = <Proxy user password>
+config.servicemanager.proxy = <Proxy URL>
+config.servicemanager.proxy_user = <Proxy user name>
+config.servicemanager.proxy_password = <Proxy user password>
 -----
 
-When these settings are applied, they are passed through to the Docker and OpenShift services. In an unauthenticated proxy environment, the `http_proxy_user` and `http_proxy_password` configurations can be omitted.
+When these settings are applied, they are passed through to the Docker and OpenShift services. In an unauthenticated proxy environment, the `proxy_user` and `proxy_password` configurations can be omitted.
+
+NOTE: `http_proxy`, `http_proxy_user` and `http_proxy_password` have been depreacted now.
 
 === Configuring Services
 The vagrant-service-manager helps you configure the service of your choice:

--- a/lib/vagrant-service-manager/config.rb
+++ b/lib/vagrant-service-manager/config.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
     OPENSHIFT_CONFIG = [
       :openshift_docker_registry, :openshift_image_name, :openshift_image_tag
     ].freeze
-    PROXY_CONFIG = [:http_proxy, :http_proxy_user, :http_proxy_password].freeze
+    PROXY_CONFIG = [:proxy, :proxy_user, :proxy_password].freeze
 
     class Config < Vagrant.plugin('2', :config)
       attr_accessor(*(BASE_CONFIG + OPENSHIFT_CONFIG + PROXY_CONFIG))

--- a/lib/vagrant-service-manager/service_base.rb
+++ b/lib/vagrant-service-manager/service_base.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
       def proxy_cmd_options
         options = ''
 
-        return options unless http_proxy_settings_valid?
+        return options unless proxy_settings_valid?
 
         PROXY_CONFIG.each do |key|
           options += "#{key.to_s.upcase}='#{@machine.config.servicemanager.send(key)}' "
@@ -30,10 +30,10 @@ module VagrantPlugins
         options.chop
       end
 
-      def http_proxy_settings_valid?
-        proxy = @machine.config.servicemanager.send('http_proxy')
-        user = @machine.config.servicemanager.send('http_proxy_user')
-        password = @machine.config.servicemanager.send('http_proxy_password')
+      def proxy_settings_valid?
+        proxy = @machine.config.servicemanager.send('proxy')
+        user = @machine.config.servicemanager.send('proxy_user')
+        password = @machine.config.servicemanager.send('proxy_password')
 
         if proxy && user.nil? && password.nil? || (proxy && user && password)
           PluginLogger.debug('Detected proxy settings. Going to apply them to service commands.')

--- a/test/vagrant-service-manager/service_base_test.rb
+++ b/test/vagrant-service-manager/service_base_test.rb
@@ -8,59 +8,59 @@ module VagrantPlugins
     let(:instance) { ServiceManager::ServiceBase.new(machine, machine.env) }
 
     it 'should build the proxy options if only proxy url is given' do
-      machine.config.servicemanager.http_proxy = 'foo:8080'
+      machine.config.servicemanager.proxy = 'foo:8080'
       options = instance.proxy_cmd_options
-      assert_match(/HTTP_PROXY='foo:8080'/, options)
+      assert_match(/PROXY='foo:8080'/, options)
     end
 
     it 'should build the proxy options if all proxy settings are given' do
-      machine.config.servicemanager.http_proxy = 'foo:8080'
-      machine.config.servicemanager.http_proxy_user = 'user'
-      machine.config.servicemanager.http_proxy_password = 'password'
+      machine.config.servicemanager.proxy = 'foo:8080'
+      machine.config.servicemanager.proxy_user = 'user'
+      machine.config.servicemanager.proxy_password = 'password'
 
       options = instance.proxy_cmd_options
-      assert_match(/HTTP_PROXY='foo:8080'/, options)
-      assert_match(/HTTP_PROXY_USER='user'/, options)
-      assert_match(/HTTP_PROXY_PASSWORD='password'/, options)
+      assert_match(/PROXY='foo:8080'/, options)
+      assert_match(/PROXY_USER='user'/, options)
+      assert_match(/PROXY_PASSWORD='password'/, options)
     end
 
     it 'should return empty proxy options if proxy url is not given' do
-      machine.config.servicemanager.http_proxy_user = 'user'
-      machine.config.servicemanager.http_proxy_password = 'password'
+      machine.config.servicemanager.proxy_user = 'user'
+      machine.config.servicemanager.proxy_password = 'password'
 
       options = instance.proxy_cmd_options
       assert_match(options, '')
     end
 
     it 'should return empty proxy options if user name not given' do
-      machine.config.servicemanager.http_proxy = 'foo:8080'
-      machine.config.servicemanager.http_proxy_password = 'password'
+      machine.config.servicemanager.proxy = 'foo:8080'
+      machine.config.servicemanager.proxy_password = 'password'
 
       options = instance.proxy_cmd_options
       assert_match(options, '')
     end
 
     it 'should return empty proxy options if password not given' do
-      machine.config.servicemanager.http_proxy = 'foo:8080'
-      machine.config.servicemanager.http_proxy_user = 'user'
+      machine.config.servicemanager.proxy = 'foo:8080'
+      machine.config.servicemanager.proxy_user = 'user'
 
       options = instance.proxy_cmd_options
       assert_match(options, '')
     end
 
     it 'should pass proxy settings as specified via Vagrant config' do
-      machine.config.servicemanager.http_proxy = 'foo:8080'
-      machine.config.servicemanager.http_proxy_user = 'user'
-      machine.config.servicemanager.http_proxy_password = 'password'
+      machine.config.servicemanager.proxy = 'foo:8080'
+      machine.config.servicemanager.proxy_user = 'user'
+      machine.config.servicemanager.proxy_password = 'password'
       command = "#{instance.proxy_cmd_options} sccli openshift"
 
       ServiceManager::PluginUtil.execute_once(machine, FakeUI, command)
 
       command_executed = machine.communicate.commands[:sudo].first
 
-      assert_match(/HTTP_PROXY='foo:8080'/, command_executed)
-      assert_match(/HTTP_PROXY_USER='user'/, command_executed)
-      assert_match(/HTTP_PROXY_PASSWORD='password'/, command_executed)
+      assert_match(/PROXY='foo:8080'/, command_executed)
+      assert_match(/PROXY_USER='user'/, command_executed)
+      assert_match(/PROXY_PASSWORD='password'/, command_executed)
     end
   end
 end


### PR DESCRIPTION
Fix #434

Now, I can see the proxy related changes inside VM.

```
$ bundle exec vagrant ssh
Last login: Fri Oct 28 12:47:16 2016
[vagrant@rhel-cdk ~]$ cat /etc/sysconfig/openshift_option 
# /etc/sysconfig/openshift_options

# Modify these options if you want to change openshift hostname
OPENSHIFT_SUBDOMAIN="$(hostname).$(/opt/adb/openshift/get_ip_address).xip.io"
NO_PROXY=127.0.0.1,10.0.2.15,10.10.10.42,172.17.0.1,.xip.io,172.30.0.0/16,172.17.0.0/16,rhel-cdk
HTTP_PROXY=http://fedora:fedora123@http://10.70.49.109:3128
HTTPS_PROXY=http://fedora:fedora123@http://10.70.49.109:3128
IMAGE="registry.access.redhat.com/openshift3/ose:v3.2.1.9"

[vagrant@rhel-cdk ~]$ cat /etc/systemd/system/docker.service.d/http-proxy.conf
[Service]
Environment="HTTP_PROXY=http://fedora:fedora123@http://10.70.49.109:3128" "NO_PROXY=localhost,127.0.0.1,::1,.xip.io,172.30.66.245"
```
