### PR TITLE
Fix #449 Update ‘oc’ version getting installed via install-cli to 1.4.0

### DIFF
--- a/lib/vagrant-service-manager/binary_handlers/cdk_openshift_binary_handler.rb
+++ b/lib/vagrant-service-manager/binary_handlers/cdk_openshift_binary_handler.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
     class CDKOpenshiftBinaryHandler < ADBOpenshiftBinaryHandler
       # Default to latest stable origin oc version for CDK as it is different than
       # OSE oc version running inside CDK development environment
-      LATEST_OC_VERSION = '1.2.1'.freeze
+      LATEST_OC_VERSION = '1.4.0'.freeze
 
       def initialize(machine, env, options)
         options['--cli-version'] = LATEST_OC_VERSION unless options['--cli-version']


### PR DESCRIPTION
Fix #449 

```
$ vagrant service-mnanager install-cli openshift
# Binary now available at /home/budhram/.vagrant.d/data/service-manager/bin/openshift/1.4.0/oc
# run binary as:
# oc <command>
export PATH=/home/budhram/.vagrant.d/data/service-manager/bin/openshift/1.4.0:$PATH

# run following command to configure your shell:
# eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager install-cli openshift  | tr -d '\r')"

$ export PATH=/home/budhram/.vagrant.d/data/service-manager/bin/openshift/1.4.0:$PAT

$ oc version
oc v1.4.0+208f053
kubernetes v1.4.0+776c994
features: Basic-Auth GSSAPI Kerberos SPNEGO

$ which oc
~/.vagrant.d/data/service-manager/bin/openshift/1.4.0/oc

```