### PR TITLE
Fix #448 install-cli fails

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,6 +40,7 @@ Metrics/AbcSize:
   Max: 20
   Exclude:
     - 'lib/vagrant-service-manager/command.rb'
+    - 'plugins/guests/redhat/cap/box_version.rb'
     - 'Rakefile'
 
 Lint/Eval:

--- a/lib/vagrant-service-manager/plugin_util.rb
+++ b/lib/vagrant-service-manager/plugin_util.rb
@@ -111,6 +111,7 @@ module VagrantPlugins
 
       def self.execute_once(machine, ui, command)
         machine.communicate.sudo(command) do |_, data|
+          next if data.chomp.empty?
           PluginLogger.debug
           return data.chomp
         end

--- a/plugins/guests/redhat/cap/box_version.rb
+++ b/plugins/guests/redhat/cap/box_version.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
               exit 126
             end
 
+            next if data.chomp.empty?
             return data.chomp if options[:script_readable]
             info = Hash[data.delete('"').split("\n").map { |e| e.split('=') }]
             return "#{info['VARIANT']} #{info['VARIANT_VERSION']}"

--- a/plugins/guests/redhat/cap/machine_ip.rb
+++ b/plugins/guests/redhat/cap/machine_ip.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
 
           PluginLogger.debug
           machine.communicate.execute(command) do |type, data|
+            next if data.chomp.empty?
             ip << data.chomp if type == :stdout
             return "IP=#{ip}" if options[:script_readable]
           end

--- a/plugins/guests/redhat/cap/os_variant.rb
+++ b/plugins/guests/redhat/cap/os_variant.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
           # TODO: execute efficient command to solve this
           return unless machine.communicate.test(command) # Return nil if command fails
           machine.communicate.execute(command) do |_, data|
+            next if data.chomp.empty?
             return data.chomp.delete('"').split('=').last
           end
         end

--- a/plugins/guests/redhat/cap/sha_id.rb
+++ b/plugins/guests/redhat/cap/sha_id.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
 
           return unless machine.communicate.test(command) # Return nil if command fails
           machine.communicate.execute(command) do |_, data|
+            next if data.chomp.empty?
             # sha256sum results in "sha_id path"
             return data.split.first
           end


### PR DESCRIPTION
Fix #448 

I suspect due to change in [vagrant 1.9.1 for winrm communicator](https://github.com/mitchellh/vagrant/commit/725824e1dd3c2225a6274df074142621751bfb14) we are having issues with Windows OS here.